### PR TITLE
Use encoding/hex pkg for generating UID strings

### DIFF
--- a/src/http/uid.go
+++ b/src/http/uid.go
@@ -2,7 +2,7 @@ package http
 
 import (
 	"crypto/rand"
-	"fmt"
+	"encoding/hex"
 	"io"
 )
 
@@ -20,5 +20,5 @@ func uid() string {
 		panic(err)
 	}
 
-	return fmt.Sprintf("%x", id)
+	return hex.EncodeToString(id)
 }

--- a/src/http/uid_test.go
+++ b/src/http/uid_test.go
@@ -1,0 +1,21 @@
+package http
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+)
+
+func BenchmarkFmtString(b *testing.B) {
+	id := []byte("1234567891234567")
+	for i := 0; i < b.N; i++ {
+		fmt.Sprintf("%x", id)
+	}
+}
+
+func BenchmarkHexString(b *testing.B) {
+	id := []byte("1234567891234567")
+	for i := 0; i < b.N; i++ {
+		hex.EncodeToString(id)
+	}
+}


### PR DESCRIPTION
Easy, non-critical, performance improvement in the `uid` function.

```
BenchmarkFmtString   5000000         711 ns/op
BenchmarkHexString  10000000         171 ns/op
```
