### PR TITLE
fix bug: a broken http connection will cause io.Copy() stuck and file’s ...

### DIFF
--- a/src/cmd/tusd/main.go
+++ b/src/cmd/tusd/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 )
 
 const basePath = "/files/"
@@ -73,8 +74,18 @@ func main() {
 
 	go handleUploads(tusHandler)
 
+	// On http package's default action, a broken http connection will cause io.Copy() stuck because it always suppose more data will coming and wait for them infinitely
+	// To prevent it happen, we should set a specific timeout value on http server
+	s := &http.Server{
+		Addr:           addr,
+		Handler:        nil,
+		ReadTimeout:    8 * time.Second,
+		WriteTimeout:   8 * time.Second,
+		MaxHeaderBytes: 0,
+	}
+
 	log.Printf("servering clients at http://localhost%s", addr)
-	if err := http.ListenAndServe(addr, nil); err != nil {
+	if err := s.ListenAndServe(); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
...offset will not be updated

To debug on this bug, I added some logs on handler.go to warning me while a file upload(method: PATCH) is begin.
The result shows me that io.Copy() stucks on a connection which is unexpected interruption.

So I set a timeout on data read/write to http server.

After all, partial logs looks on their right way,
Show them here with comment:

1st http connect broken:

> patchFile enter
> WriteFileChunk will call io.Copy(8f300b5a06e1337363690a9a141c1659, 0)
> WriteFileChunk return io.Copy n=3828828
> setOffset enter, offset=3828828
> WriteFileChunk end of io.Copy
> error h.store.WriteFileChunk
> 2013/12/12 07:29:17.374662 error: read tcp 192.168.1.106:54234: i/o timeout

2nd http connect broken:

> patchFile enter
> WriteFileChunk will call io.Copy(8f300b5a06e1337363690a9a141c1659, 3828828)
> WriteFileChunk return io.Copy n=4365849
> setOffset enter, offset=8194677
> WriteFileChunk end of io.Copy
> error h.store.WriteFileChunk
> 2013/12/12 07:30:29.098481 error: read tcp 192.168.1.106:54751: i/o timeout

3rd http connect and whole file uploaded:

> patchFile enter
> WriteFileChunk will call io.Copy(8f300b5a06e1337363690a9a141c1659, 8194677)
> WriteFileChunk return io.Copy n=12396883
> setOffset enter, offset=20591560
> WriteFileChunk end of io.Copy
> return patchFile
