### PR TITLE
Refactoring file locking out of tusd.Handler

### DIFF
--- a/cmd/tusd/main.go
+++ b/cmd/tusd/main.go
@@ -39,9 +39,7 @@ func main() {
 	}
 
 	var store tusd.DataStore
-	store = filestore.FileStore{
-		Path: dir,
-	}
+	store = filestore.NewFileStore(dir)
 
 	if storeSize > 0 {
 		store = limitedstore.New(storeSize, store)

--- a/datastore.go
+++ b/datastore.go
@@ -2,7 +2,14 @@ package tusd
 
 import (
 	"io"
+    "errors"
 )
+
+// Error indicating that the data store has locked the file for further edits.
+// This error is not a part of the official tus specification. Implementers of
+// tusd.DataStore have the option to return this error to signal a file is
+// locked for writing, and cannot be written to by another HTTP request.
+var ErrFileLocked = errors.New("file currently locked")
 
 type MetaData map[string]string
 

--- a/datastore.go
+++ b/datastore.go
@@ -1,8 +1,8 @@
 package tusd
 
 import (
+	"errors"
 	"io"
-    "errors"
 )
 
 // Error indicating that the data store has locked the file for further edits.

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -7,7 +7,7 @@
 package filestore
 
 import (
-    "bytes"
+	"bytes"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -25,16 +25,16 @@ type FileStore struct {
 	// Relative or absolute path to store files in. FileStore does not check
 	// whether the path exists, you os.MkdirAll in this case on your own.
 	Path  string
-    locks map[string]bool
+	locks map[string]bool
 }
 
 // NewFileStore creates a new FileStore instance.
 func NewFileStore(path string) (store *FileStore) {
-    store = &FileStore{
-        Path: path,
-        locks: make(map[string]bool),
-    }
-    return
+	store = &FileStore{
+		Path:  path,
+		locks: make(map[string]bool),
+	}
+	return
 }
 
 func (store *FileStore) NewUpload(info tusd.FileInfo) (id string, err error) {
@@ -55,11 +55,11 @@ func (store *FileStore) NewUpload(info tusd.FileInfo) (id string, err error) {
 
 func (store *FileStore) WriteChunk(id string, offset int64, src io.Reader) (int64, error) {
 	if !store.getLock(id) {
-	    return 0, tusd.ErrFileLocked
+		return 0, tusd.ErrFileLocked
 	}
-    defer store.clearLock(id)
-    
-    file, err := os.OpenFile(store.binPath(id), os.O_WRONLY|os.O_APPEND, defaultFilePerm)
+	defer store.clearLock(id)
+
+	file, err := os.OpenFile(store.binPath(id), os.O_WRONLY|os.O_APPEND, defaultFilePerm)
 	if err != nil {
 		return 0, err
 	}
@@ -75,7 +75,7 @@ func (store *FileStore) WriteChunk(id string, offset int64, src io.Reader) (int6
 }
 
 func (store *FileStore) GetInfo(id string) (info tusd.FileInfo, err error) {
-    data, err := ioutil.ReadFile(store.infoPath(id))
+	data, err := ioutil.ReadFile(store.infoPath(id))
 	if err != nil {
 		return info, err
 	}
@@ -85,17 +85,17 @@ func (store *FileStore) GetInfo(id string) (info tusd.FileInfo, err error) {
 
 func (store *FileStore) GetReader(id string) (io.Reader, error) {
 	if !store.getLock(id) {
-	    return bytes.NewReader(make([]byte, 0)), tusd.ErrFileLocked
+		return bytes.NewReader(make([]byte, 0)), tusd.ErrFileLocked
 	}
-    defer store.clearLock(id)
-    return os.Open(store.binPath(id))
+	defer store.clearLock(id)
+	return os.Open(store.binPath(id))
 }
 
 func (store *FileStore) Terminate(id string) error {
-    if !store.getLock(id) {
-        return tusd.ErrFileLocked
-    }
-    defer store.clearLock(id)
+	if !store.getLock(id) {
+		return tusd.ErrFileLocked
+	}
+	defer store.clearLock(id)
 	if err := os.Remove(store.infoPath(id)); err != nil {
 		return err
 	}
@@ -142,16 +142,16 @@ func (store *FileStore) setOffset(id string, offset int64) error {
 
 // getLock obtains a lock on reading/writing data for the given file ID.
 func (store *FileStore) getLock(id string) (hasLock bool) {
-    if _, locked := store.locks[id]; locked {
-        hasLock = false
-        return
-    }
-    store.locks[id] = true
-    hasLock = true
-    return
+	if _, locked := store.locks[id]; locked {
+		hasLock = false
+		return
+	}
+	store.locks[id] = true
+	hasLock = true
+	return
 }
 
 // clearLock removes the lock for the given file ID.
 func (store *FileStore) clearLock(id string) {
-    delete(store.locks, id)
+	delete(store.locks, id)
 }

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -98,7 +98,7 @@ func (store *FileStore) Terminate(id string) error {
 	return nil
 }
 
-func (store *FileStore) LockFile(id string) (hasLock bool, err) {
+func (store *FileStore) LockFile(id string) (hasLock bool, err error) {
 	info, err := store.GetInfo(id)
 	if err != nil {
 		hasLock = false
@@ -110,7 +110,7 @@ func (store *FileStore) LockFile(id string) (hasLock bool, err) {
 		return
 	}
 	info.Locked = true
-	err = writeInfo(id, info)
+	err = store.writeInfo(id, info)
 	if err != nil {
 		hasLock = false
 		return
@@ -125,7 +125,7 @@ func (store *FileStore) UnlockFile(id string) (err error) {
 		return
 	}
 	info.Locked = false
-	err = writeInfo(info)
+	err = store.writeInfo(id, info)
 	return
 }
 

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -7,6 +7,7 @@
 package filestore
 
 import (
+    "bytes"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -23,10 +24,20 @@ var defaultFilePerm = os.FileMode(0775)
 type FileStore struct {
 	// Relative or absolute path to store files in. FileStore does not check
 	// whether the path exists, you os.MkdirAll in this case on your own.
-	Path string
+	Path  string
+    locks map[string]bool
 }
 
-func (store FileStore) NewUpload(info tusd.FileInfo) (id string, err error) {
+// NewFileStore creates a new FileStore instance.
+func NewFileStore(path string) (store *FileStore) {
+    store = &FileStore{
+        Path: path,
+        locks: make(map[string]bool),
+    }
+    return
+}
+
+func (store *FileStore) NewUpload(info tusd.FileInfo) (id string, err error) {
 	id = uid.Uid()
 	info.ID = id
 
@@ -42,8 +53,13 @@ func (store FileStore) NewUpload(info tusd.FileInfo) (id string, err error) {
 	return
 }
 
-func (store FileStore) WriteChunk(id string, offset int64, src io.Reader) (int64, error) {
-	file, err := os.OpenFile(store.binPath(id), os.O_WRONLY|os.O_APPEND, defaultFilePerm)
+func (store *FileStore) WriteChunk(id string, offset int64, src io.Reader) (int64, error) {
+	if !store.getLock(id) {
+	    return 0, tusd.ErrFileLocked
+	}
+    defer store.clearLock(id)
+    
+    file, err := os.OpenFile(store.binPath(id), os.O_WRONLY|os.O_APPEND, defaultFilePerm)
 	if err != nil {
 		return 0, err
 	}
@@ -58,21 +74,28 @@ func (store FileStore) WriteChunk(id string, offset int64, src io.Reader) (int64
 	return n, err
 }
 
-func (store FileStore) GetInfo(id string) (tusd.FileInfo, error) {
-	info := tusd.FileInfo{}
-	data, err := ioutil.ReadFile(store.infoPath(id))
+func (store *FileStore) GetInfo(id string) (info tusd.FileInfo, err error) {
+    data, err := ioutil.ReadFile(store.infoPath(id))
 	if err != nil {
 		return info, err
 	}
 	err = json.Unmarshal(data, &info)
-	return info, err
+	return
 }
 
-func (store FileStore) GetReader(id string) (io.Reader, error) {
-	return os.Open(store.binPath(id))
+func (store *FileStore) GetReader(id string) (io.Reader, error) {
+	if !store.getLock(id) {
+	    return bytes.NewReader(make([]byte, 0)), tusd.ErrFileLocked
+	}
+    defer store.clearLock(id)
+    return os.Open(store.binPath(id))
 }
 
-func (store FileStore) Terminate(id string) error {
+func (store *FileStore) Terminate(id string) error {
+    if !store.getLock(id) {
+        return tusd.ErrFileLocked
+    }
+    defer store.clearLock(id)
 	if err := os.Remove(store.infoPath(id)); err != nil {
 		return err
 	}
@@ -83,17 +106,17 @@ func (store FileStore) Terminate(id string) error {
 }
 
 // Return the path to the .bin storing the binary data
-func (store FileStore) binPath(id string) string {
+func (store *FileStore) binPath(id string) string {
 	return store.Path + "/" + id + ".bin"
 }
 
 // Return the path to the .info file storing the file's info
-func (store FileStore) infoPath(id string) string {
+func (store *FileStore) infoPath(id string) string {
 	return store.Path + "/" + id + ".info"
 }
 
 // Update the entire information. Everything will be overwritten.
-func (store FileStore) writeInfo(id string, info tusd.FileInfo) error {
+func (store *FileStore) writeInfo(id string, info tusd.FileInfo) error {
 	data, err := json.Marshal(info)
 	if err != nil {
 		return err
@@ -102,7 +125,7 @@ func (store FileStore) writeInfo(id string, info tusd.FileInfo) error {
 }
 
 // Update the .info file using the new upload.
-func (store FileStore) setOffset(id string, offset int64) error {
+func (store *FileStore) setOffset(id string, offset int64) error {
 	info, err := store.GetInfo(id)
 	if err != nil {
 		return err
@@ -115,4 +138,20 @@ func (store FileStore) setOffset(id string, offset int64) error {
 
 	info.Offset = offset
 	return store.writeInfo(id, info)
+}
+
+// getLock obtains a lock on reading/writing data for the given file ID.
+func (store *FileStore) getLock(id string) (hasLock bool) {
+    if _, locked := store.locks[id]; locked {
+        hasLock = false
+        return
+    }
+    store.locks[id] = true
+    hasLock = true
+    return
+}
+
+// clearLock removes the lock for the given file ID.
+func (store *FileStore) clearLock(id string) {
+    delete(store.locks, id)
 }

--- a/filestore/filestore_test.go
+++ b/filestore/filestore_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Test interface implementation of Filestore
-var _ tusd.DataStore = FileStore{}
+var _ tusd.DataStore = NewFileStore("")
 
 func TestFilestore(t *testing.T) {
 	tmp, err := ioutil.TempDir("", "tusd-filestore-")
@@ -19,7 +19,7 @@ func TestFilestore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	store := FileStore{tmp}
+	store := NewFileStore(tmp)
 
 	// Create new upload
 	id, err := store.NewUpload(tusd.FileInfo{

--- a/handler_test.go
+++ b/handler_test.go
@@ -28,6 +28,14 @@ func (store zeroStore) Terminate(id string) error {
 	return ErrNotImplemented
 }
 
+func (store zeroStore) LockFile(id string) (bool, error) {
+	return true, nil
+}
+
+func (store zeroStore) UnlockFile(id string) (error) {
+	return nil
+}
+
 type httpTest struct {
 	Name string
 

--- a/limitedstore/limitedstore_test.go
+++ b/limitedstore/limitedstore_test.go
@@ -49,6 +49,14 @@ func (store *dataStore) Terminate(id string) error {
 	return nil
 }
 
+func (store *dataStore) LockFile(id string) (bool, error) {
+	return true, nil
+}
+
+func (store *dataStore) UnlockFile(id string) (error) {
+	return nil
+}
+
 func TestLimitedStore(t *testing.T) {
 	dataStore := &dataStore{
 		t: t,


### PR DESCRIPTION
This resolves #22 

* Updated filestore.FileStore implementation to use simple locking scheme. Refactored to make interface use pointers. Removed locks from tusd.Handler
* Refactored sample code to use pointer implementation of FileStore.
* Moved ErrFileLocked variable to datastore.go