### PR TITLE
Expose handler methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ func main() {
 	// Create a new HTTP handler for the tusd server by providing
 	// a configuration object. The DataStore property must be set
 	// in order to allow the handler to function.
-	handler, err := tusd.NewHandler(tusd.Config{
+	handler, err := tusd.NewRoutedHandler(tusd.Config{
 		BasePath:              "files/",
 		DataStore:             store,
 	})
@@ -77,6 +77,9 @@ func main() {
 	}
 }
 ```
+
+If you need to customize the GET and DELETE endpoints use `tusd.NewHandler`
+instead of `tusd.NewRoutedHandler`.
 
 ## Implementing own storages
 

--- a/cmd/tusd/main.go
+++ b/cmd/tusd/main.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"flag"
-	"github.com/tus/tusd"
-	"github.com/tus/tusd/filestore"
-	"github.com/tus/tusd/limitedstore"
 	"log"
 	"net"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/tus/tusd"
+	"github.com/tus/tusd/filestore"
+	"github.com/tus/tusd/limitedstore"
 )
 
 var httpHost string
@@ -59,7 +60,7 @@ func main() {
 
 	stdout.Printf("Using %.2fMB as maximum size.\n", float64(maxSize)/1024/1024)
 
-	handler, err := tusd.NewHandler(tusd.Config{
+	handler, err := tusd.NewRoutedHandler(tusd.Config{
 		MaxSize:               maxSize,
 		BasePath:              "files/",
 		DataStore:             store,

--- a/concat_test.go
+++ b/concat_test.go
@@ -37,7 +37,7 @@ func (s concatPartialStore) GetInfo(id string) (FileInfo, error) {
 }
 
 func TestConcatPartial(t *testing.T) {
-	handler, _ := NewHandler(Config{
+	handler, _ := NewRoutedHandler(Config{
 		MaxSize:  400,
 		BasePath: "files",
 		DataStore: concatPartialStore{
@@ -150,7 +150,7 @@ func (s concatFinalStore) WriteChunk(id string, offset int64, src io.Reader) (in
 }
 
 func TestConcatFinal(t *testing.T) {
-	handler, _ := NewHandler(Config{
+	handler, _ := NewRoutedHandler(Config{
 		MaxSize:  400,
 		BasePath: "files",
 		DataStore: concatFinalStore{
@@ -193,7 +193,7 @@ func TestConcatFinal(t *testing.T) {
 		Code: http.StatusBadRequest,
 	}).Run(handler, t)
 
-	handler, _ = NewHandler(Config{
+	handler, _ = NewRoutedHandler(Config{
 		MaxSize:  9,
 		BasePath: "files",
 		DataStore: concatFinalStore{

--- a/cors_test.go
+++ b/cors_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestCORS(t *testing.T) {
-	handler, _ := NewHandler(Config{})
+	handler, _ := NewRoutedHandler(Config{})
 
 	(&httpTest{
 		Name:   "Preflight request",

--- a/get_test.go
+++ b/get_test.go
@@ -42,7 +42,7 @@ var reader = &closingStringReader{
 }
 
 func TestGet(t *testing.T) {
-	handler, _ := NewHandler(Config{
+	handler, _ := NewRoutedHandler(Config{
 		DataStore: getStore{},
 	})
 

--- a/handler.go
+++ b/handler.go
@@ -459,11 +459,11 @@ func (handler *Handler) sendError(w http.ResponseWriter, r *http.Request, err er
 	if r.Method == "HEAD" {
 		reason = ""
 	}
-
+	reason += "\n"
 	w.Header().Set("Content-Type", "text/plain")
 	w.Header().Set("Content-Length", strconv.Itoa(len(reason)))
 	w.WriteHeader(status)
-	w.Write([]byte(err.Error()))
+	w.Write([]byte(reason))
 }
 
 // Make an absolute URLs to the given upload id. If the base path is absolute

--- a/handler.go
+++ b/handler.go
@@ -298,7 +298,7 @@ func (handler *Handler) PatchFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := r.URL.Query().Get(":id")
+	id := extractIDFromPath(r.URL.Path)
 
 	// Ensure file is not locked
 	if _, ok := handler.locks[id]; ok {
@@ -370,7 +370,7 @@ func (handler *Handler) PatchFile(w http.ResponseWriter, r *http.Request) {
 // GetFile handles requests to download a file using a GET request. This is not
 // part of the specification.
 func (handler *Handler) GetFile(w http.ResponseWriter, r *http.Request) {
-	id := r.URL.Query().Get(":id")
+	id := extractIDFromPath(r.URL.Path)
 
 	// Ensure file is not locked
 	if _, ok := handler.locks[id]; ok {
@@ -417,7 +417,7 @@ func (handler *Handler) GetFile(w http.ResponseWriter, r *http.Request) {
 
 // DelFile terminates an upload permanently.
 func (handler *Handler) DelFile(w http.ResponseWriter, r *http.Request) {
-	id := r.URL.Query().Get(":id")
+	id := extractIDFromPath(r.URL.Path)
 
 	// Ensure file is not locked
 	if _, ok := handler.locks[id]; ok {
@@ -594,14 +594,13 @@ func parseConcat(header string) (isPartial bool, isFinal bool, partialUploads []
 				continue
 			}
 
-			// Extract ids out of URL
-			result := reExtractFileID.FindStringSubmatch(value)
-			if len(result) != 2 {
+			id := extractIDFromPath(value)
+			if id == "" {
 				err = ErrInvalidConcat
 				return
 			}
 
-			partialUploads = append(partialUploads, result[1])
+			partialUploads = append(partialUploads, id)
 		}
 	}
 
@@ -612,4 +611,13 @@ func parseConcat(header string) (isPartial bool, isFinal bool, partialUploads []
 	}
 
 	return
+}
+
+// extractIDFromPath pulls the last segment from the url provided
+func extractIDFromPath(url string) string {
+	result := reExtractFileID.FindStringSubmatch(url)
+	if len(result) != 2 {
+		return ""
+	}
+	return result[1]
 }

--- a/handler.go
+++ b/handler.go
@@ -80,7 +80,10 @@ type Handler struct {
 	CompleteUploads chan FileInfo
 }
 
-// Create a new handler using the given configuration.
+// NewHandler creates a new handler without routing using the given
+// configuration. It exposes the http handlers which need to be combined with
+// a router (aka mux) of your choice. If you are looking for preconfigured
+// handler see NewRoutedHandler.
 func NewHandler(config Config) (*Handler, error) {
 	logger := config.Logger
 	if logger == nil {
@@ -175,7 +178,7 @@ func (handler *Handler) TusMiddleware(h http.Handler) http.Handler {
 
 // Create a new file upload using the datastore after validating the length
 // and parsing the metadata.
-func (handler *Handler) postFile(w http.ResponseWriter, r *http.Request) {
+func (handler *Handler) PostFile(w http.ResponseWriter, r *http.Request) {
 	// Parse Upload-Concat header
 	isPartial, isFinal, partialUploads, err := parseConcat(r.Header.Get("Upload-Concat"))
 	if err != nil {
@@ -237,7 +240,7 @@ func (handler *Handler) postFile(w http.ResponseWriter, r *http.Request) {
 }
 
 // Returns the length and offset for the HEAD request
-func (handler *Handler) headFile(w http.ResponseWriter, r *http.Request) {
+func (handler *Handler) HeadFile(w http.ResponseWriter, r *http.Request) {
 
 	id := r.URL.Query().Get(":id")
 	info, err := handler.dataStore.GetInfo(id)
@@ -271,7 +274,7 @@ func (handler *Handler) headFile(w http.ResponseWriter, r *http.Request) {
 
 // Add a chunk to an upload. Only allowed if the upload is not locked and enough
 // space is left.
-func (handler *Handler) patchFile(w http.ResponseWriter, r *http.Request) {
+func (handler *Handler) PatchFile(w http.ResponseWriter, r *http.Request) {
 
 	//Check for presence of application/offset+octet-stream
 	if r.Header.Get("Content-Type") != "application/offset+octet-stream" {
@@ -356,7 +359,7 @@ func (handler *Handler) patchFile(w http.ResponseWriter, r *http.Request) {
 }
 
 // Download a file using a GET request. This is not part of the specification.
-func (handler *Handler) getFile(w http.ResponseWriter, r *http.Request) {
+func (handler *Handler) GetFile(w http.ResponseWriter, r *http.Request) {
 	id := r.URL.Query().Get(":id")
 
 	// Ensure file is not locked
@@ -403,7 +406,7 @@ func (handler *Handler) getFile(w http.ResponseWriter, r *http.Request) {
 }
 
 // Terminate an upload permanently.
-func (handler *Handler) delFile(w http.ResponseWriter, r *http.Request) {
+func (handler *Handler) DelFile(w http.ResponseWriter, r *http.Request) {
 	id := r.URL.Query().Get(":id")
 
 	// Ensure file is not locked

--- a/head_test.go
+++ b/head_test.go
@@ -26,7 +26,7 @@ func (s headStore) GetInfo(id string) (FileInfo, error) {
 }
 
 func TestHead(t *testing.T) {
-	handler, _ := NewHandler(Config{
+	handler, _ := NewRoutedHandler(Config{
 		BasePath:  "https://buy.art/",
 		DataStore: headStore{},
 	})

--- a/head_test.go
+++ b/head_test.go
@@ -3,6 +3,7 @@ package tusd
 import (
 	"net/http"
 	"os"
+	"strconv"
 	"testing"
 )
 
@@ -46,14 +47,32 @@ func TestHead(t *testing.T) {
 			"Cache-Control":   "no-store",
 		},
 	}).Run(handler, t)
+}
 
-	(&httpTest{
+func TestHead404(t *testing.T) {
+	handler, _ := NewRoutedHandler(Config{
+		BasePath:  "https://buy.art/",
+		DataStore: headStore{},
+	})
+
+	resp := (&httpTest{
 		Name:   "Non-existing file",
 		Method: "HEAD",
 		URL:    "no",
 		ReqHeader: map[string]string{
 			"Tus-Resumable": "1.0.0",
 		},
-		Code: http.StatusNotFound,
+		Code:    http.StatusNotFound,
+		ResBody: "",
 	}).Run(handler, t)
+
+	body := string(resp.Body.Bytes())
+	if body != "\n" {
+		t.Errorf("Expected body to be empty. Got: %v", body)
+	}
+
+	contentLength := resp.Header().Get("Content-Length")
+	if contentLength != strconv.Itoa(len(body)) {
+		t.Errorf("Expected content length header to match body length. Got: %v", contentLength)
+	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestOptions(t *testing.T) {
-	handler, _ := NewHandler(Config{
+	handler, _ := NewRoutedHandler(Config{
 		MaxSize: 400,
 	})
 

--- a/patch_test.go
+++ b/patch_test.go
@@ -49,7 +49,7 @@ func (s patchStore) WriteChunk(id string, offset int64, src io.Reader) (int64, e
 }
 
 func TestPatch(t *testing.T) {
-	handler, _ := NewHandler(Config{
+	handler, _ := NewRoutedHandler(Config{
 		MaxSize: 100,
 		DataStore: patchStore{
 			t: t,
@@ -178,7 +178,7 @@ func (r *noEOFReader) Write(src []byte) (int, error) {
 }
 
 func TestPatchOverflow(t *testing.T) {
-	handler, _ := NewHandler(Config{
+	handler, _ := NewRoutedHandler(Config{
 		MaxSize: 100,
 		DataStore: overflowPatchStore{
 			t: t,

--- a/post_test.go
+++ b/post_test.go
@@ -32,7 +32,7 @@ func (s postStore) NewUpload(info FileInfo) (string, error) {
 }
 
 func TestPost(t *testing.T) {
-	handler, _ := NewHandler(Config{
+	handler, _ := NewRoutedHandler(Config{
 		MaxSize:  400,
 		BasePath: "files",
 		DataStore: postStore{

--- a/routed_handler.go
+++ b/routed_handler.go
@@ -6,12 +6,20 @@ import (
 	"github.com/bmizerany/pat"
 )
 
+// RoutedHandler is a ready to use handler with routing (using pat)
 type RoutedHandler struct {
 	handler         *Handler
 	routeHandler    http.Handler
 	CompleteUploads chan FileInfo
 }
 
+// NewRoutedHandler creates a routed tus protocol handler. This is the simplest
+// way to use tusd but may not be as configurable as you require. If you are
+// integrating this into an existing app you may like to use tusd.NewHandler
+// instead. Using tusd.NewHandler allows the tus handlers to be combined into
+// your existing router (aka mux) directly. It also allows the GET and DELETE
+// endpoints to be customized. These are not part of the protocol so can be
+// changed depending on your needs.
 func NewRoutedHandler(config Config) (*RoutedHandler, error) {
 	handler, err := NewHandler(config)
 	if err != nil {

--- a/routed_handler.go
+++ b/routed_handler.go
@@ -1,0 +1,42 @@
+package tusd
+
+import (
+	"net/http"
+
+	"github.com/bmizerany/pat"
+)
+
+type RoutedHandler struct {
+	handler         *Handler
+	routeHandler    http.Handler
+	CompleteUploads chan FileInfo
+}
+
+func NewRoutedHandler(config Config) (*RoutedHandler, error) {
+	handler, err := NewHandler(config)
+	if err != nil {
+		return nil, err
+	}
+
+	routedHandler := &RoutedHandler{
+		handler:         handler,
+		CompleteUploads: handler.CompleteUploads,
+	}
+
+	mux := pat.New()
+
+	routedHandler.routeHandler = handler.TusMiddleware(mux)
+
+	mux.Post("", http.HandlerFunc(handler.postFile))
+	mux.Head(":id", http.HandlerFunc(handler.headFile))
+	mux.Get(":id", http.HandlerFunc(handler.getFile))
+	mux.Del(":id", http.HandlerFunc(handler.delFile))
+	mux.Add("PATCH", ":id", http.HandlerFunc(handler.patchFile))
+
+	return routedHandler, nil
+}
+
+// ServeHTTP Implements the http.Handler interface.
+func (rHandler *RoutedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rHandler.routeHandler.ServeHTTP(w, r)
+}

--- a/routed_handler.go
+++ b/routed_handler.go
@@ -27,11 +27,11 @@ func NewRoutedHandler(config Config) (*RoutedHandler, error) {
 
 	routedHandler.routeHandler = handler.TusMiddleware(mux)
 
-	mux.Post("", http.HandlerFunc(handler.postFile))
-	mux.Head(":id", http.HandlerFunc(handler.headFile))
-	mux.Get(":id", http.HandlerFunc(handler.getFile))
-	mux.Del(":id", http.HandlerFunc(handler.delFile))
-	mux.Add("PATCH", ":id", http.HandlerFunc(handler.patchFile))
+	mux.Post("", http.HandlerFunc(handler.PostFile))
+	mux.Head(":id", http.HandlerFunc(handler.HeadFile))
+	mux.Get(":id", http.HandlerFunc(handler.GetFile))
+	mux.Del(":id", http.HandlerFunc(handler.DelFile))
+	mux.Add("PATCH", ":id", http.HandlerFunc(handler.PatchFile))
 
 	return routedHandler, nil
 }

--- a/routed_handler_test.go
+++ b/routed_handler_test.go
@@ -106,7 +106,7 @@ func TestMethodOverride(t *testing.T) {
 	store := &methodOverrideStore{
 		t: t,
 	}
-	handler, _ := NewHandler(Config{
+	handler, _ := NewRoutedHandler(Config{
 		DataStore: store,
 	})
 

--- a/routed_handler_test.go
+++ b/routed_handler_test.go
@@ -44,7 +44,7 @@ type httpTest struct {
 	ResHeader map[string]string
 }
 
-func (test *httpTest) Run(handler http.Handler, t *testing.T) {
+func (test *httpTest) Run(handler http.Handler, t *testing.T) *httptest.ResponseRecorder {
 	t.Log(test.Name)
 
 	req, _ := http.NewRequest(test.Method, test.URL, test.ReqBody)
@@ -77,6 +77,8 @@ func (test *httpTest) Run(handler http.Handler, t *testing.T) {
 	if test.ResBody != "" && string(w.Body.Bytes()) != test.ResBody {
 		t.Errorf("Expected '%s' as body (got '%s'", test.ResBody, string(w.Body.Bytes()))
 	}
+
+	return w
 }
 
 type methodOverrideStore struct {

--- a/terminate_test.go
+++ b/terminate_test.go
@@ -18,7 +18,7 @@ func (s terminateStore) Terminate(id string) error {
 }
 
 func TestTerminate(t *testing.T) {
-	handler, _ := NewHandler(Config{
+	handler, _ := NewRoutedHandler(Config{
 		DataStore: terminateStore{
 			t: t,
 		},


### PR DESCRIPTION
This PR is driven by a couple of desires for the app i am building. 
- I wanted to be able to remove the DELETE endpoint as it is not a feature needed by the app.
- I wanted to be able to customise the GET endpoint to return json with the status of the background job which is initiated by the upload rather than the actual file uploaded.
- The app i am building uses httprouter and was hoping to avoid nested http routers for performance reasons.

Hopefully these are reasonable from your perspective! 

Let me know if you want anything changed