### PR TITLE
Sorting before termination of uploads in limitedstore.go

### DIFF
--- a/limitedstore/limitedstore.go
+++ b/limitedstore/limitedstore.go
@@ -106,7 +106,7 @@ func (store *LimitedStore) ensureSpace(size int64) error {
 
   // Forward traversal through the
   // uploads in terms of size, biggest upload first
-  for _,k := sorted_uploads {
+  for _,k := range sorted_uploads {
     id := k.key
 		if err := store.terminate(id); err != nil {
 			return err
@@ -116,7 +116,6 @@ func (store *LimitedStore) ensureSpace(size int64) error {
 			// Enough space has been freed to store the new upload
 			return nil
 		}
-    j--
 	}
 
 	return nil

--- a/limitedstore/limitedstore.go
+++ b/limitedstore/limitedstore.go
@@ -102,13 +102,12 @@ func (store *LimitedStore) ensureSpace(size int64) error {
     sorted_uploads[i] = Pair{u, h}
     i++
   }
-  sort.Sort(sorted_uploads)
+  sort.Sort(sort.Reverse(sorted_uploads))
 
-  // Reverse traversal through the
+  // Forward traversal through the
   // uploads in terms of size, biggest upload first
-  j := len(store.uploads)-1
-	for j >= 0 {
-    id := sorted_uploads[j].key
+  for _,k := sorted_uploads {
+    id := k.key
 		if err := store.terminate(id); err != nil {
 			return err
 		}

--- a/limitedstore/limitedstore.go
+++ b/limitedstore/limitedstore.go
@@ -106,7 +106,7 @@ func (store *LimitedStore) ensureSpace(size int64) error {
 
   // Reverse traversal through the
   // uploads in terms of size, biggest upload first
-  j := len(store.uploads)
+  j := len(store.uploads)-1
 	for j >= 0 {
     id := sorted_uploads[j].key
 		if err := store.terminate(id); err != nil {

--- a/limitedstore/limitedstore.go
+++ b/limitedstore/limitedstore.go
@@ -27,17 +27,17 @@ type LimitedStore struct {
 	mutex *sync.Mutex
 }
 
-// Pair structure to perform map-sorting
-type Pair struct {
+// pair structure to perform map-sorting
+type pair struct {
   key string
   value int64
 }
 
-type Pairlist []Pair
+type pairlist []pair
 
-func (p Pairlist) Len() int           { return len(p) }
-func (p Pairlist) Swap(i, j int)       { p[i], p[j] = p[j], p[i] }
-func (p Pairlist) Less(i, j int) bool  { return p[i].value < p[j].value }
+func (p pairlist) Len() int           { return len(p) }
+func (p pairlist) Swap(i, j int)       { p[i], p[j] = p[j], p[i] }
+func (p pairlist) Less(i, j int) bool  { return p[i].value < p[j].value }
 
 
 // Create a new limited store with the given size as the maximum storage size
@@ -96,10 +96,10 @@ func (store *LimitedStore) ensureSpace(size int64) error {
 		// Enough space is available to store the new upload
 		return nil
 	}
-  sorted_uploads := make(Pairlist, len(store.uploads))
+  sorted_uploads := make(pairlist, len(store.uploads))
   i := 0
   for u,h := range store.uploads {
-    sorted_uploads[i] = Pair{u, h}
+    sorted_uploads[i] = pair{u, h}
     i++
   }
   sort.Sort(sort.Reverse(sorted_uploads))


### PR DESCRIPTION
This fix is in limitedstore/limitedstore.go, to intelligently terminate existing file uploads. The ```store.uploads``` map is sorted, and then analysed to remove the bigger existing uploads first. 

The extraneous Pair and Pairlist structures are created in order to sort the map by values. Sorry for the indentation issues, surprisingly they didn't sync.