### PR TITLE
Add test for content length on 404

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -44,7 +44,7 @@ type httpTest struct {
 	ResHeader map[string]string
 }
 
-func (test *httpTest) Run(handler http.Handler, t *testing.T) {
+func (test *httpTest) Run(handler http.Handler, t *testing.T) *httptest.ResponseRecorder {
 	t.Log(test.Name)
 
 	req, _ := http.NewRequest(test.Method, test.URL, test.ReqBody)
@@ -77,6 +77,8 @@ func (test *httpTest) Run(handler http.Handler, t *testing.T) {
 	if test.ResBody != "" && string(w.Body.Bytes()) != test.ResBody {
 		t.Errorf("Expected '%s' as body (got '%s'", test.ResBody, string(w.Body.Bytes()))
 	}
+
+	return w
 }
 
 type methodOverrideStore struct {


### PR DESCRIPTION
This is a test for an issue which was resolved in #31. This test was extracted from #29