### PR TITLE
Support 0 as a "no timeout" setting

### DIFF
--- a/cmd/tusd/main.go
+++ b/cmd/tusd/main.go
@@ -255,18 +255,32 @@ type Conn struct {
 }
 
 func (c *Conn) Read(b []byte) (int, error) {
-	err := c.Conn.SetReadDeadline(time.Now().Add(c.ReadTimeout))
+	var err error
+	if c.ReadTimeout > 0 {
+		err = c.Conn.SetReadDeadline(time.Now().Add(c.ReadTimeout))
+	} else {
+		err = c.Conn.SetReadDeadline(0)
+	}
+
 	if err != nil {
 		return 0, err
 	}
+
 	return c.Conn.Read(b)
 }
 
 func (c *Conn) Write(b []byte) (int, error) {
-	err := c.Conn.SetWriteDeadline(time.Now().Add(c.WriteTimeout))
+	var err error
+	if c.WriteTimeout > 0 {
+		err = c.Conn.SetWriteDeadline(time.Now().Add(c.WriteTimeout))
+	} else {
+		err = c.Conn.SetWriteDeadline(0)
+	}
+
 	if err != nil {
 		return 0, err
 	}
+
 	return c.Conn.Write(b)
 }
 

--- a/cmd/tusd/main.go
+++ b/cmd/tusd/main.go
@@ -259,7 +259,7 @@ func (c *Conn) Read(b []byte) (int, error) {
 	if c.ReadTimeout > 0 {
 		err = c.Conn.SetReadDeadline(time.Now().Add(c.ReadTimeout))
 	} else {
-		err = c.Conn.SetReadDeadline(0)
+		err = c.Conn.SetReadDeadline(time.Time{})
 	}
 
 	if err != nil {
@@ -274,7 +274,7 @@ func (c *Conn) Write(b []byte) (int, error) {
 	if c.WriteTimeout > 0 {
 		err = c.Conn.SetWriteDeadline(time.Now().Add(c.WriteTimeout))
 	} else {
-		err = c.Conn.SetWriteDeadline(0)
+		err = c.Conn.SetWriteDeadline(time.Time{})
 	}
 
 	if err != nil {

--- a/cmd/tusd/main.go
+++ b/cmd/tusd/main.go
@@ -55,7 +55,7 @@ func init() {
 	flag.StringVar(&dir, "dir", "./data", "Directory to store uploads in")
 	flag.Int64Var(&storeSize, "store-size", 0, "Size of space allowed for storage")
 	flag.StringVar(&basepath, "base-path", "/files/", "Basepath of the HTTP server")
-	flag.Int64Var(&timeout, "timeout", 30*1000, "Read timeout for connections in milliseconds")
+	flag.Int64Var(&timeout, "timeout", 30*1000, "Read timeout for connections in milliseconds.  A zero value means that reads will not timeout")
 	flag.StringVar(&s3Bucket, "s3-bucket", "", "Use AWS S3 with this bucket as storage backend (requires the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_REGION environment variables to be set)")
 	flag.StringVar(&hooksDir, "hooks-dir", "", "")
 	flag.BoolVar(&version, "version", false, "Print tusd version information")


### PR DESCRIPTION
If you are working behind a load balancer the load balancer might handle this and send an EOF.  In that case, you want to have no read and write timeouts at all, so we should support the 0 setting as "unlimited" just like the Connection itself.