### PR TITLE
Add -s3-endpoint to command line arguments to support S3 compatilbe implementations like minio

### DIFF
--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -14,6 +14,7 @@ var Flags struct {
 	Basepath      string
 	Timeout       int64
 	S3Bucket      string
+	S3Endpoint    string
 	HooksDir      string
 	ShowVersion   bool
 	ExposeMetrics bool
@@ -32,6 +33,7 @@ func ParseFlags() {
 	flag.StringVar(&Flags.Basepath, "base-path", "/files/", "Basepath of the HTTP server")
 	flag.Int64Var(&Flags.Timeout, "timeout", 30*1000, "Read timeout for connections in milliseconds.  A zero value means that reads will not timeout")
 	flag.StringVar(&Flags.S3Bucket, "s3-bucket", "", "Use AWS S3 with this bucket as storage backend (requires the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_REGION environment variables to be set)")
+	flag.StringVar(&Flags.S3Endpoint, "s3-endpoint", "", "Endpoint to use S3 compatible implementations like minio (requires s3-bucket to be pass)")
 	flag.StringVar(&Flags.HooksDir, "hooks-dir", "", "Directory to search for available hooks scripts")
 	flag.BoolVar(&Flags.ShowVersion, "version", false, "Print tusd version information")
 	flag.BoolVar(&Flags.ExposeMetrics, "expose-metrics", true, "Expose metrics about tusd usage")


### PR DESCRIPTION
How to test:
Download and run [minio](https://github.com/minio/minio) : ./minio server /tmp/minio-test-files
Go to http://127.0.0.1:9000 (minio web UI) and create a bucket with name "test"
Set AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_REGION from output of minio.
Run : go run cmd/tusd/main.go -s3-bucket test -s3-endpoint http://127.0.0.1:9000.
Run tus-js-client demo and set upload endpoit to http://localhost:1080/files/ and chunk size to 5242880 bytes(5MB).
Upload some files to test.
Refresh minio web UI.

This maybe work with new version of Ceph(Kraken) but not with Jewel because of an old version of embedded web server(civetweb) that doesn't support absolute URI.