### PR TITLE
HTTP 423 can be replaced by http.StatusLocked

### DIFF
--- a/unrouted_handler.go
+++ b/unrouted_handler.go
@@ -51,7 +51,7 @@ var (
 	ErrInvalidUploadLength = NewHTTPError(errors.New("missing or invalid Upload-Length header"), http.StatusBadRequest)
 	ErrInvalidOffset       = NewHTTPError(errors.New("missing or invalid Upload-Offset header"), http.StatusBadRequest)
 	ErrNotFound            = NewHTTPError(errors.New("upload not found"), http.StatusNotFound)
-	ErrFileLocked          = NewHTTPError(errors.New("file currently locked"), 423) // Locked (WebDAV) (RFC 4918)
+	ErrFileLocked          = NewHTTPError(errors.New("file currently locked"), http.StatusLocked)
 	ErrMismatchOffset      = NewHTTPError(errors.New("mismatched offset"), http.StatusConflict)
 	ErrSizeExceeded        = NewHTTPError(errors.New("resource's size exceeded"), http.StatusRequestEntityTooLarge)
 	ErrNotImplemented      = NewHTTPError(errors.New("feature not implemented"), http.StatusNotImplemented)


### PR DESCRIPTION
See https://golang.org/src/net/http/status.go?h=StatusLocked#L55