### PR TITLE
tmplock must be closed before removal

### DIFF
--- a/vendor/gopkg.in/Acconut/lockfile.v1/lockfile.go
+++ b/vendor/gopkg.in/Acconut/lockfile.v1/lockfile.go
@@ -82,8 +82,10 @@ func (l Lockfile) TryLock() error {
 	if err != nil {
 		return err
 	} else {
-		defer tmplock.Close()
-		defer os.Remove(tmplock.Name())
+		defer func(){
+			tmplock.Close()
+			os.Remove(tmplock.Name())
+		}()
 	}
 
 	_, err = tmplock.WriteString(fmt.Sprintf("%d\n", os.Getpid()))


### PR DESCRIPTION
`defer` are called in LIFO style, so `os.Remove` was called before `tmplock.Close` (which is obviously wrong).

Since this a dependency, I don't know how it should be fixed...

*(don't update to the latest version of https://github.com/nightlyone/lockfile: if the same process acquire a lock two times, it won't fail because the pid is the same)*