### PR TITLE
working alpine Dockerfile usable for local and autobuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ RUN addgroup -g 1000 tusd \
     && apk del git
 
 WORKDIR /srv/tusd-data
-VOLUME ["/srv/tusd-data"]
-VOLUME ["/srv/tusd-hooks"]
 EXPOSE 1080
 USER tusd
 ENTRYPOINT ["/go/bin/tusd","-dir","/srv/tusd-data","--hooks-dir","/srv/tusd-hooks"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM golang:1.7-alpine
+
+# Copy in the git repo from the build context
+COPY . /go/src/github.com/tus/tusd/
+
+# Create app directory
+
+RUN addgroup -g 1000 tusd \
+    && adduser -u 1000 -G tusd -s /bin/sh -D tusd \
+    && cd /go/src/github.com/tus/tusd \
+    && apk add --no-cache \
+        git \
+    && go get -d -v ./... \
+    && version="$(git tag -l --points-at HEAD)" \
+    && commit=$(git log --format="%H" -n 1) \
+    && GOOS=linux GOARCH=amd64 go build \
+        -ldflags="-X github.com/tus/tusd/cmd/tusd/cli.VersionName=${version} -X github.com/tus/tusd/cmd/tusd/cli.GitCommit=${commit} -X 'github.com/tus/tusd/cmd/tusd/cli.BuildDate=$(date --utc)'" \
+        -o "/go/bin/tusd" ./cmd/tusd/main.go \
+    && mkdir -p /srv/tusd-data \
+    && mkdir -p /srv/tusd-hooks \
+    && chown tusd:tusd /srv/tusd-data \
+    && rm -r /go/src/* \
+    && apk del git
+
+WORKDIR /srv/tusd-data
+VOLUME ["/srv/tusd-data"]
+VOLUME ["/srv/tusd-hooks"]
+EXPOSE 1080
+USER tusd
+ENTRYPOINT ["/go/bin/tusd","-dir","/srv/tusd-data","--hooks-dir","/srv/tusd-hooks"]


### PR DESCRIPTION
This Dockerfile works quite nicely and produces an image of only 256 MB. 

Docker entrypoint is configured to make use of the dirs /srv/tusd-data and /srv/tusd-hooks. You can therefore mount an outside dir with your private hooks onto /srv/tusd-hooks and tusd will automatically use them. 

As the image is using ENTRYPOINT for the basic start command, it is possible to provide additional startup args to tusd by adding them to `docker run` after the image name:

### Example Docker run command
`docker run --name tusd -it -v $PWD/tusd-data/:/srv/tusd-data/ -v $PWD/tusd-hooks/:/srv/tusd-hooks -e AWS_REGION=eu-central-1 flaneurtv/tusd -s3-bucket tusd-bucket -s3-endpoint https://s3.eu-central-1.amazonaws.com`

The Dockerfile should work for both, local builds as well as Docker Hub automatic builds. However, judging from the way things are structured in most "official" Docker builds, a little tweaking will still be needed to satisfy Docker, while this is not more than an educated guess.

I am happy to provide further help on the path towards becoming a Docker official image.