### PR TITLE
added post-create hook

### DIFF
--- a/.hooks/post-create
+++ b/.hooks/post-create
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+id="$TUS_ID"
+offset="$TUS_OFFSET"
+size="$TUS_SIZE"
+progress=$((100 * $offset/$size))
+
+echo "Upload created with ID ${id} and size ${size}"
+cat /dev/stdin | jq .

--- a/cmd/tusd/cli/hooks.go
+++ b/cmd/tusd/cli/hooks.go
@@ -22,6 +22,7 @@ const (
 	HookPostFinish    HookType = "post-finish"
 	HookPostTerminate HookType = "post-terminate"
 	HookPostReceive   HookType = "post-receive"
+	HookPostCreate    HookType = "post-create"
 	HookPreCreate     HookType = "pre-create"
 )
 
@@ -52,6 +53,8 @@ func SetupPostHooks(handler *tusd.Handler) {
 				invokeHook(HookPostTerminate, info)
 			case info := <-handler.UploadProgress:
 				invokeHook(HookPostReceive, info)
+			case info := <-handler.UploadCreated:
+				invokeHook(HookPostCreate, info)
 			}
 		}
 	}()
@@ -66,6 +69,8 @@ func invokeHook(typ HookType, info tusd.FileInfo) {
 
 func invokeHookSync(typ HookType, info tusd.FileInfo, captureOutput bool) ([]byte, error) {
 	switch typ {
+	case HookPostCreate:
+		logEv("UploadCreated", "id", info.ID, "size", strconv.FormatInt(info.Size, 10))
 	case HookPostFinish:
 		logEv("UploadFinished", "id", info.ID, "size", strconv.FormatInt(info.Size, 10))
 	case HookPostTerminate:

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -18,6 +18,7 @@ func Serve() {
 		NotifyCompleteUploads:   true,
 		NotifyTerminatedUploads: true,
 		NotifyUploadProgress:    true,
+		NotifyUploadCreated:     true,
 	})
 	if err != nil {
 		stderr.Fatalf("Unable to create handler: %s", err)

--- a/config.go
+++ b/config.go
@@ -34,6 +34,9 @@ type Config struct {
 	// NotifyUploadProgress indicates whether sending notifications about
 	// the upload progress using the UploadProgress channel should be enabled.
 	NotifyUploadProgress bool
+	// NotifyUploadCreated indicates whether sending notifications about
+	// the upload having been created using the UploadCreated channel should be enabled.
+	NotifyUploadCreated bool
 	// Logger is the logger to use internally, mostly for printing requests.
 	Logger *log.Logger
 	// Respect the X-Forwarded-Host, X-Forwarded-Proto and Forwarded headers


### PR DESCRIPTION
The post-create hook triggers right after the upload has been created. Its purpose is to inform other services of the existence of the new upload, e.g. to trigger actions in the background.

Please review.

Regards,
Markus

