### PR TITLE
added .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,go,yml,json}]
+charset = utf-8
+
+[*.go]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This is for convenience. Most editors have a plugin available for .editorconfig. This makes it more convenient to keep code formatting consistent.

http://EditorConfig.org