### PR TITLE
calculating PartSize based on size of upload

### DIFF
--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -565,27 +565,33 @@ func (store S3Store) CalcOptimalPartSize(size int64) (int64, error) {
 	switch {
 	// We can only manage files up to MaxObjectSize, else we need to fail.
 	case size > store.MaxObjectSize:
+		fmt.Print("0 ")
 		return 0, fmt.Errorf("CalcOptimalPartSize: size of %v bytes exceeds MaxObjectSize of %v bytes", size, store.MaxObjectSize)
 	// When upload is smaller or equal MinPartSize, we upload in just one part.
 	case size <= store.MinPartSize:
+		fmt.Print("A ")
 		return store.MinPartSize, nil
 	// When we need 9999 parts or less with MinPartSize.
 	case size/store.MinPartSize < store.MaxMultipartParts:
+		fmt.Print("B ")
 		return store.MinPartSize, nil
-	// When we can divide our upload into exactly MaxMultipartParts parts with
-	// no bytes leftover, we will not need an spare last part.
-	// Also, when MaxObjectSize is equal to MaxPartSize * MaxMultipartParts
+	// If our upload divides up exactly into MaxMultipartParts parts with
+	// no bytes leftover, we will not need an spare last part. So we can go with
+	// a straight division. Otherwise we would exceed MaxPartSize in a scenario,
+	// where MaxObjectSize is equal to MaxPartSize * MaxMultipartParts
 	// (which is not the case with the current AWS S3 API specification, but
-	// might be in the future or with other S3-aware stores), we need this in
-	// order for our Multipart-Upload to reach full MaxObjectSize.
+	// might be in the future or with other S3-aware stores).
 	case size%store.MaxMultipartParts == 0:
+		fmt.Print("C ")
 		return size / store.MaxMultipartParts, nil
-	// If the last part would be larger than MaxPartSize, which is only the case
-	// when we are close to MaxObjectSize, we have to go with MaxPartSize.
-	case size%(store.MaxMultipartParts-1) > store.MaxPartSize:
-		return store.MaxPartSize, nil
-	// In all other cases, we need a spare last piece for the remaining bytes.
+	// In all other cases, we need to round up to the next integer, as long as we
+	// stay below MaxPartSize.
+	case size/store.MaxMultipartParts < store.MaxPartSize:
+		fmt.Print("D ")
+		return size/store.MaxMultipartParts + 1, nil
+	// If non of the above matches, we have exceeded the MaxPartSize limit above.
 	default:
-		return size / (store.MaxMultipartParts - 1), nil
+		fmt.Print("X ")
+		return size/store.MaxMultipartParts + 1, fmt.Errorf("CalcOptimalPartSize: to upload %v bytes optimalPartSize %v must exceed MaxPartSize %v", size, (size/store.MaxMultipartParts + 1), store.MaxPartSize)
 	}
 }

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -562,6 +562,11 @@ func isAwsError(err error, code string) bool {
 }
 
 func (store S3Store) CalcOptimalPartSize(size int64) (optimalPartSize int64, err error) {
+	// an upload larger than MaxObjectSize must throw an error
+	if size > store.MaxObjectSize {
+		return 0, fmt.Errorf("CalcOptimalPartSize: upload size of %v bytes exceeds MaxObjectSize of %v bytes", size, store.MaxObjectSize)
+	}
+
 	switch {
 	// When upload is smaller or equal MinPartSize, we upload in just one part.
 	case size <= store.MinPartSize:
@@ -598,10 +603,6 @@ func (store S3Store) CalcOptimalPartSize(size int64) (optimalPartSize int64, err
 		optimalPartSize = size/store.MaxMultipartParts + 1
 	}
 
-	// an upload larger than MaxObjectSize must throw an error
-	if size > store.MaxObjectSize {
-		return optimalPartSize, fmt.Errorf("CalcOptimalPartSize: upload size of %v bytes exceeds MaxObjectSize of %v bytes", size, store.MaxObjectSize)
-	}
 	// optimalPartSize must never exceed MaxPartSize
 	if optimalPartSize > store.MaxPartSize {
 		return optimalPartSize, fmt.Errorf("CalcOptimalPartSize: to upload %v bytes optimalPartSize %v must exceed MaxPartSize %v", size, optimalPartSize, store.MaxPartSize)

--- a/s3store/s3store_test.go
+++ b/s3store/s3store_test.go
@@ -43,117 +43,127 @@ func TestCalcOptimalPartSize(t *testing.T) {
 		store.MaxObjectSize = 200
 	*/
 
-	debug := false
 	// If you want the results of all tests printed
-	// debug = true
-
-	var MinPartSize = store.MinPartSize
-	var MaxPartSize = store.MaxPartSize
-	var MaxMultipartParts = store.MaxMultipartParts
-	var MaxObjectSize = store.MaxObjectSize
+	var debug = true
 	var equalparts, lastpartsize int64
-	var err string
 
 	// sanity check
-	if MaxObjectSize > MaxPartSize*MaxMultipartParts {
-		t.Errorf("MaxObjectSize %v can never be achieved, as MaxMultipartParts %v and MaxPartSize %v only allow for an upload of %v bytes total.\n", MaxObjectSize, MaxMultipartParts, MaxPartSize, MaxMultipartParts*MaxPartSize)
+	if store.MaxObjectSize > store.MaxPartSize*store.MaxMultipartParts {
+		t.Errorf("MaxObjectSize %v can never be achieved, as MaxMultipartParts %v and MaxPartSize %v only allow for an upload of %v bytes total.\n", store.MaxObjectSize, store.MaxMultipartParts, store.MaxPartSize, store.MaxMultipartParts*store.MaxPartSize)
 	}
-	var HighestApplicablePartSize int64 = MaxObjectSize / MaxMultipartParts
-	if MaxObjectSize%MaxMultipartParts > 0 {
+
+	var HighestApplicablePartSize int64 = store.MaxObjectSize / store.MaxMultipartParts
+	if store.MaxObjectSize%store.MaxMultipartParts > 0 {
 		HighestApplicablePartSize++
 	}
-	var RemainderWithHighestApplicablePartSize int64 = MaxObjectSize % HighestApplicablePartSize
+	var RemainderWithHighestApplicablePartSize int64 = store.MaxObjectSize % HighestApplicablePartSize
 
 	// some of these tests are actually duplicates, as they specify the same size
 	// in bytes - two ways to describe the same thing. That is wanted, in order
 	// to provide a full picture from any angle.
 	testcases := []int64{
 		1,
-		MinPartSize - 1,
-		MinPartSize,
-		MinPartSize + 1,
+		store.MinPartSize - 1,
+		store.MinPartSize,
+		store.MinPartSize + 1,
 
-		MinPartSize*(MaxMultipartParts-1) - 1,
-		MinPartSize * (MaxMultipartParts - 1),
-		MinPartSize*(MaxMultipartParts-1) + 1,
+		store.MinPartSize*(store.MaxMultipartParts-1) - 1,
+		store.MinPartSize * (store.MaxMultipartParts - 1),
+		store.MinPartSize*(store.MaxMultipartParts-1) + 1,
 
-		MinPartSize*MaxMultipartParts - 1,
-		MinPartSize * MaxMultipartParts,
-		MinPartSize*MaxMultipartParts + 1,
+		store.MinPartSize*store.MaxMultipartParts - 1,
+		store.MinPartSize * store.MaxMultipartParts,
+		store.MinPartSize*store.MaxMultipartParts + 1,
 
-		MinPartSize*(MaxMultipartParts+1) - 1,
-		MinPartSize * (MaxMultipartParts + 1),
-		MinPartSize*(MaxMultipartParts+1) + 1,
+		store.MinPartSize*(store.MaxMultipartParts+1) - 1,
+		store.MinPartSize * (store.MaxMultipartParts + 1),
+		store.MinPartSize*(store.MaxMultipartParts+1) + 1,
 
-		(HighestApplicablePartSize-1)*MaxMultipartParts - 1,
-		(HighestApplicablePartSize - 1) * MaxMultipartParts,
-		(HighestApplicablePartSize-1)*MaxMultipartParts + 1,
+		(HighestApplicablePartSize-1)*store.MaxMultipartParts - 1,
+		(HighestApplicablePartSize - 1) * store.MaxMultipartParts,
+		(HighestApplicablePartSize-1)*store.MaxMultipartParts + 1,
 
-		HighestApplicablePartSize*(MaxMultipartParts-1) - 1,
-		HighestApplicablePartSize * (MaxMultipartParts - 1),
-		HighestApplicablePartSize*(MaxMultipartParts-1) + 1,
+		HighestApplicablePartSize*(store.MaxMultipartParts-1) - 1,
+		HighestApplicablePartSize * (store.MaxMultipartParts - 1),
+		HighestApplicablePartSize*(store.MaxMultipartParts-1) + 1,
 
-		HighestApplicablePartSize*(MaxMultipartParts-1) + RemainderWithHighestApplicablePartSize - 1,
-		HighestApplicablePartSize*(MaxMultipartParts-1) + RemainderWithHighestApplicablePartSize,
-		HighestApplicablePartSize*(MaxMultipartParts-1) + RemainderWithHighestApplicablePartSize + 1,
+		HighestApplicablePartSize*(store.MaxMultipartParts-1) + RemainderWithHighestApplicablePartSize - 1,
+		HighestApplicablePartSize*(store.MaxMultipartParts-1) + RemainderWithHighestApplicablePartSize,
+		HighestApplicablePartSize*(store.MaxMultipartParts-1) + RemainderWithHighestApplicablePartSize + 1,
 
-		MaxObjectSize - 1,
-		MaxObjectSize,
-		MaxObjectSize + 1,
+		store.MaxObjectSize - 1,
+		store.MaxObjectSize,
+		store.MaxObjectSize + 1,
 
-		(MaxObjectSize/MaxMultipartParts)*(MaxMultipartParts-1) - 1,
-		(MaxObjectSize / MaxMultipartParts) * (MaxMultipartParts - 1),
-		(MaxObjectSize/MaxMultipartParts)*(MaxMultipartParts-1) + 1,
+		(store.MaxObjectSize/store.MaxMultipartParts)*(store.MaxMultipartParts-1) - 1,
+		(store.MaxObjectSize / store.MaxMultipartParts) * (store.MaxMultipartParts - 1),
+		(store.MaxObjectSize/store.MaxMultipartParts)*(store.MaxMultipartParts-1) + 1,
 
-		MaxPartSize*(MaxMultipartParts-1) - 1,
-		MaxPartSize * (MaxMultipartParts - 1),
-		MaxPartSize*(MaxMultipartParts-1) + 1,
+		store.MaxPartSize*(store.MaxMultipartParts-1) - 1,
+		store.MaxPartSize * (store.MaxMultipartParts - 1),
+		store.MaxPartSize*(store.MaxMultipartParts-1) + 1,
 
-		MaxPartSize*MaxMultipartParts - 1,
-		MaxPartSize * MaxMultipartParts,
-		MaxPartSize*MaxMultipartParts + 1,
+		store.MaxPartSize*store.MaxMultipartParts - 1,
+		store.MaxPartSize * store.MaxMultipartParts,
+		store.MaxPartSize*store.MaxMultipartParts + 1,
 	}
 
-	for index, size := range testcases {
-		err = ""
+	for _, size := range testcases {
 		optimalPartSize, calcError := store.CalcOptimalPartSize(size)
-		if size > MaxObjectSize && calcError == nil {
-			err += fmt.Sprintf("Testcase #%v size %v: size exceeds MaxObjectSize %v but no error returned\n", index, size, MaxObjectSize)
-		}
-		if debug && optimalPartSize == 0 {
-			fmt.Printf("Testcase #%v size %v: size exceeds MaxObjectSize %v\n", index, size, MaxObjectSize)
-		}
-		if optimalPartSize > 0 {
-			equalparts = size / optimalPartSize
-			lastpartsize = size % optimalPartSize
-			if optimalPartSize < MinPartSize {
-				err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: optimalPartSize < MinPartSize %v\n", index, size, equalparts, optimalPartSize, lastpartsize, MinPartSize)
-			}
-			if optimalPartSize > MaxPartSize && calcError == nil {
-				err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: optimalPartSize > MaxPartSize %v\n", index, size, equalparts, optimalPartSize, lastpartsize, MaxPartSize)
-			}
-			if size%optimalPartSize == 0 && equalparts > MaxMultipartParts {
-				err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v\n", index, size, equalparts, optimalPartSize, lastpartsize, MaxMultipartParts)
-			}
-			if size%optimalPartSize > 0 && equalparts > MaxMultipartParts-1 {
-				err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v\n", index, size, equalparts, optimalPartSize, lastpartsize, MaxMultipartParts)
-			}
-			if lastpartsize > MaxPartSize {
-				err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: lastpart > MaxPartSize %v\n", index, size, equalparts, optimalPartSize, lastpartsize, MaxPartSize)
-			}
-			if lastpartsize > optimalPartSize {
-				err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: lastpart > optimalPartSize %v\n", index, size, equalparts, optimalPartSize, lastpartsize, optimalPartSize)
-			}
-			if debug {
-				fmt.Printf("Testcase #%v size %v, %v parts of size %v, lastpart %v\n", index, size, equalparts, optimalPartSize, lastpartsize)
-			}
-		}
-		if len(err) > 0 {
-			t.Errorf(err)
+		equalparts = size / optimalPartSize
+		lastpartsize = size % optimalPartSize
+		assert.False(optimalPartSize < store.MinPartSize, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: optimalPartSize < MinPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MinPartSize))
+		assert.False(optimalPartSize > store.MaxPartSize && calcError == nil, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: optimalPartSize > MaxPartSize %v, but no error was returned.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxPartSize))
+		assert.False(size%optimalPartSize == 0 && equalparts > store.MaxMultipartParts, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxMultipartParts))
+		assert.False(size%optimalPartSize > 0 && equalparts > store.MaxMultipartParts-1, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxMultipartParts))
+		assert.False(lastpartsize > store.MaxPartSize, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: lastpart > MaxPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxPartSize))
+		assert.False(lastpartsize > optimalPartSize, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: lastpart > optimalPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, optimalPartSize))
+		if debug {
+			fmt.Printf("Size %v, %v parts of size %v, lastpart %v, does exceed MaxObjectSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, size > store.MaxObjectSize)
 		}
 	}
 	// fmt.Println("HighestApplicablePartSize", HighestApplicablePartSize)
 	// fmt.Println("RemainderWithHighestApplicablePartSize", RemainderWithHighestApplicablePartSize)
+}
+
+func TestAllPartSizes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	assert := assert.New(t)
+
+	s3obj := NewMockS3API(mockCtrl)
+	store := s3store.New("bucket", s3obj)
+
+	store.MinPartSize = 5
+	store.MaxPartSize = 5 * 1024
+	store.MaxMultipartParts = 1000
+	store.MaxObjectSize = store.MaxPartSize * store.MaxMultipartParts
+
+	var debug = false
+	var equalparts, lastpartsize int64
+
+	// sanity check
+	if store.MaxObjectSize > store.MaxPartSize*store.MaxMultipartParts {
+		t.Errorf("MaxObjectSize %v can never be achieved, as MaxMultipartParts %v and MaxPartSize %v only allow for an upload of %v bytes total.\n", store.MaxObjectSize, store.MaxMultipartParts, store.MaxPartSize, store.MaxMultipartParts*store.MaxPartSize)
+	}
+
+	for size := int64(1); size <= store.MaxObjectSize; size++ {
+		optimalPartSize, calcError := store.CalcOptimalPartSize(size)
+		equalparts = size / optimalPartSize
+		lastpartsize = size % optimalPartSize
+		assert.False(optimalPartSize < store.MinPartSize, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: optimalPartSize < MinPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MinPartSize))
+		assert.False(optimalPartSize > store.MaxPartSize && calcError == nil, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: optimalPartSize > MaxPartSize %v, but no error was returned.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxPartSize))
+		assert.False(size%optimalPartSize == 0 && equalparts > store.MaxMultipartParts, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxMultipartParts))
+		assert.False(size%optimalPartSize > 0 && equalparts > store.MaxMultipartParts-1, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxMultipartParts))
+		assert.False(lastpartsize > store.MaxPartSize, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: lastpart > MaxPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxPartSize))
+		assert.False(lastpartsize > optimalPartSize, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: lastpart > optimalPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, optimalPartSize))
+		if debug {
+			fmt.Printf("Size %v, %v parts of size %v, lastpart %v, does exceed MaxObjectSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, size > store.MaxObjectSize)
+		}
+	}
 }
 
 func TestNewUpload(t *testing.T) {
@@ -202,6 +212,55 @@ func TestNewUpload(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal("uploadId+multipartId", id)
 }
+
+/*
+func TestNewUploadLargerMaxObjectSize(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	assert := assert.New(t)
+
+	s3obj := NewMockS3API(mockCtrl)
+	store := s3store.New("bucket", s3obj)
+
+	assert.Equal("bucket", store.Bucket)
+	assert.Equal(s3obj, store.Service)
+
+	s1 := "hello"
+	s2 := "men?"
+
+	gomock.InOrder(
+		s3obj.EXPECT().CreateMultipartUpload(&s3.CreateMultipartUploadInput{
+			Bucket: aws.String("bucket"),
+			Key:    aws.String("uploadId"),
+			Metadata: map[string]*string{
+				"foo": &s1,
+				"bar": &s2,
+			},
+		}).Return(&s3.CreateMultipartUploadOutput{
+			UploadId: aws.String("multipartId"),
+		}, nil),
+		s3obj.EXPECT().PutObject(&s3.PutObjectInput{
+			Bucket:        aws.String("bucket"),
+			Key:           aws.String("uploadId.info"),
+			Body:          bytes.NewReader([]byte(`{"ID":"uploadId+multipartId","Size":500,"Offset":0,"MetaData":{"bar":"menü","foo":"hello"},"IsPartial":false,"IsFinal":false,"PartialUploads":null}`)),
+			ContentLength: aws.Int64(int64(148)),
+		}),
+	)
+
+	info := tusd.FileInfo{
+		ID:   "uploadId",
+		Size: 500,
+		MetaData: map[string]string{
+			"foo": "hello",
+			"bar": "menü",
+		},
+	}
+
+	id, err := store.NewUpload(info)
+	assert.Nil(err)
+	assert.Equal("uploadId+multipartId", id)
+}
+*/
 
 func TestGetInfoNotFound(t *testing.T) {
 	mockCtrl := gomock.NewController(t)

--- a/s3store/s3store_test.go
+++ b/s3store/s3store_test.go
@@ -214,7 +214,6 @@ func TestNewUpload(t *testing.T) {
 	assert.Equal("uploadId+multipartId", id)
 }
 
-/*
 func TestNewUploadLargerMaxObjectSize(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -226,42 +225,16 @@ func TestNewUploadLargerMaxObjectSize(t *testing.T) {
 	assert.Equal("bucket", store.Bucket)
 	assert.Equal(s3obj, store.Service)
 
-	s1 := "hello"
-	s2 := "men?"
-
-	gomock.InOrder(
-		s3obj.EXPECT().CreateMultipartUpload(&s3.CreateMultipartUploadInput{
-			Bucket: aws.String("bucket"),
-			Key:    aws.String("uploadId"),
-			Metadata: map[string]*string{
-				"foo": &s1,
-				"bar": &s2,
-			},
-		}).Return(&s3.CreateMultipartUploadOutput{
-			UploadId: aws.String("multipartId"),
-		}, nil),
-		s3obj.EXPECT().PutObject(&s3.PutObjectInput{
-			Bucket:        aws.String("bucket"),
-			Key:           aws.String("uploadId.info"),
-			Body:          bytes.NewReader([]byte(`{"ID":"uploadId+multipartId","Size":500,"Offset":0,"MetaData":{"bar":"menü","foo":"hello"},"IsPartial":false,"IsFinal":false,"PartialUploads":null}`)),
-			ContentLength: aws.Int64(int64(148)),
-		}),
-	)
-
 	info := tusd.FileInfo{
 		ID:   "uploadId",
-		Size: 500,
-		MetaData: map[string]string{
-			"foo": "hello",
-			"bar": "menü",
-		},
+		Size: store.MaxObjectSize + 1,
 	}
 
 	id, err := store.NewUpload(info)
-	assert.Nil(err)
-	assert.Equal("uploadId+multipartId", id)
+	assert.NotNil(err)
+	assert.EqualError(err, fmt.Sprintf("s3store: upload size of %v bytes exceeds MaxObjectSize of %v bytes", info.Size, store.MaxObjectSize))
+	assert.Equal("", id)
 }
-*/
 
 func TestGetInfoNotFound(t *testing.T) {
 	mockCtrl := gomock.NewController(t)

--- a/s3store/s3store_test.go
+++ b/s3store/s3store_test.go
@@ -43,6 +43,10 @@ func TestCalcOptimalPartSize(t *testing.T) {
 		store.MaxObjectSize = 200
 	*/
 
+	debug := false
+	// If you want the results of all tests printed
+	// debug = true
+
 	var MinPartSize = store.MinPartSize
 	var MaxPartSize = store.MaxPartSize
 	var MaxMultipartParts = store.MaxMultipartParts
@@ -114,9 +118,12 @@ func TestCalcOptimalPartSize(t *testing.T) {
 		err = ""
 		optimalPartSize, calcError := store.CalcOptimalPartSize(size)
 		if size > MaxObjectSize && calcError == nil {
-			err += fmt.Sprintf("Testcase #%v size %v: size exceeds MaxObjectSize=%v but no error returned\n", index, size, MaxObjectSize)
+			err += fmt.Sprintf("Testcase #%v size %v: size exceeds MaxObjectSize %v but no error returned\n", index, size, MaxObjectSize)
 		}
-		if calcError == nil {
+		if debug && optimalPartSize == 0 {
+			fmt.Printf("Testcase #%v size %v: size exceeds MaxObjectSize %v\n", index, size, MaxObjectSize)
+		}
+		if optimalPartSize > 0 {
 			equalparts = size / optimalPartSize
 			lastpartsize = size % optimalPartSize
 			if optimalPartSize < MinPartSize {
@@ -137,8 +144,10 @@ func TestCalcOptimalPartSize(t *testing.T) {
 			if lastpartsize > optimalPartSize {
 				err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: lastpart > optimalPartSize %v\n", index, size, equalparts, optimalPartSize, lastpartsize, optimalPartSize)
 			}
+			if debug {
+				fmt.Printf("Testcase #%v size %v, %v parts of size %v, lastpart %v\n", index, size, equalparts, optimalPartSize, lastpartsize)
+			}
 		}
-		// fmt.Printf("Testcase #%v size %v, %v parts of size %v, lastpart %v\n", index, size, equalparts, optimalPartSize, lastpartsize)
 		if len(err) > 0 {
 			t.Errorf(err)
 		}

--- a/s3store/s3store_test.go
+++ b/s3store/s3store_test.go
@@ -113,28 +113,30 @@ func TestCalcOptimalPartSize(t *testing.T) {
 	for index, size := range testcases {
 		err = ""
 		optimalPartSize, calcError := store.CalcOptimalPartSize(size)
-		equalparts = size / optimalPartSize
-		lastpartsize = size % optimalPartSize
 		if size > MaxObjectSize && calcError == nil {
 			err += fmt.Sprintf("Testcase #%v size %v: size exceeds MaxObjectSize=%v but no error returned\n", index, size, MaxObjectSize)
 		}
-		if optimalPartSize < MinPartSize {
-			err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: optimalPartSize < MinPartSize %v\n", index, size, equalparts, optimalPartSize, lastpartsize, MinPartSize)
-		}
-		if optimalPartSize > MaxPartSize && calcError == nil {
-			err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: optimalPartSize > MaxPartSize %v\n", index, size, equalparts, optimalPartSize, lastpartsize, MaxPartSize)
-		}
-		if size%optimalPartSize == 0 && equalparts > MaxMultipartParts {
-			err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v\n", index, size, equalparts, optimalPartSize, lastpartsize, MaxMultipartParts)
-		}
-		if size%optimalPartSize > 0 && equalparts > MaxMultipartParts-1 {
-			err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v\n", index, size, equalparts, optimalPartSize, lastpartsize, MaxMultipartParts)
-		}
-		if lastpartsize > MaxPartSize {
-			err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: lastpart > MaxPartSize %v\n", index, size, equalparts, optimalPartSize, lastpartsize, MaxPartSize)
-		}
-		if lastpartsize > optimalPartSize {
-			err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: lastpart > optimalPartSize %v\n", index, size, equalparts, optimalPartSize, lastpartsize, optimalPartSize)
+		if calcError == nil {
+			equalparts = size / optimalPartSize
+			lastpartsize = size % optimalPartSize
+			if optimalPartSize < MinPartSize {
+				err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: optimalPartSize < MinPartSize %v\n", index, size, equalparts, optimalPartSize, lastpartsize, MinPartSize)
+			}
+			if optimalPartSize > MaxPartSize && calcError == nil {
+				err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: optimalPartSize > MaxPartSize %v\n", index, size, equalparts, optimalPartSize, lastpartsize, MaxPartSize)
+			}
+			if size%optimalPartSize == 0 && equalparts > MaxMultipartParts {
+				err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v\n", index, size, equalparts, optimalPartSize, lastpartsize, MaxMultipartParts)
+			}
+			if size%optimalPartSize > 0 && equalparts > MaxMultipartParts-1 {
+				err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v\n", index, size, equalparts, optimalPartSize, lastpartsize, MaxMultipartParts)
+			}
+			if lastpartsize > MaxPartSize {
+				err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: lastpart > MaxPartSize %v\n", index, size, equalparts, optimalPartSize, lastpartsize, MaxPartSize)
+			}
+			if lastpartsize > optimalPartSize {
+				err += fmt.Sprintf("Testcase #%v size %v, %v parts of size %v, lastpart %v: lastpart > optimalPartSize %v\n", index, size, equalparts, optimalPartSize, lastpartsize, optimalPartSize)
+			}
 		}
 		// fmt.Printf("Testcase #%v size %v, %v parts of size %v, lastpart %v\n", index, size, equalparts, optimalPartSize, lastpartsize)
 		if len(err) > 0 {

--- a/s3store/s3store_test.go
+++ b/s3store/s3store_test.go
@@ -44,7 +44,7 @@ func TestCalcOptimalPartSize(t *testing.T) {
 	*/
 
 	// If you want the results of all tests printed
-	var debug = true
+	var debug = false
 	var equalparts, lastpartsize int64
 
 	// sanity check

--- a/s3store/s3store_test.go
+++ b/s3store/s3store_test.go
@@ -62,6 +62,7 @@ func TestCalcOptimalPartSize(t *testing.T) {
 	// in bytes - two ways to describe the same thing. That is wanted, in order
 	// to provide a full picture from any angle.
 	testcases := []int64{
+		0,
 		1,
 		store.MinPartSize - 1,
 		store.MinPartSize,
@@ -112,12 +113,12 @@ func TestCalcOptimalPartSize(t *testing.T) {
 		optimalPartSize, calcError := store.CalcOptimalPartSize(size)
 		equalparts = size / optimalPartSize
 		lastpartsize = size % optimalPartSize
-		assert.False(optimalPartSize < store.MinPartSize, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: optimalPartSize < MinPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MinPartSize))
-		assert.False(optimalPartSize > store.MaxPartSize && calcError == nil, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: optimalPartSize > MaxPartSize %v, but no error was returned.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxPartSize))
-		assert.False(size%optimalPartSize == 0 && equalparts > store.MaxMultipartParts, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxMultipartParts))
-		assert.False(size%optimalPartSize > 0 && equalparts > store.MaxMultipartParts-1, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxMultipartParts))
-		assert.False(lastpartsize > store.MaxPartSize, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: lastpart > MaxPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxPartSize))
-		assert.False(lastpartsize > optimalPartSize, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: lastpart > optimalPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, optimalPartSize))
+		assert.False(optimalPartSize < store.MinPartSize, "Size %v, %v parts of size %v, lastpart %v: optimalPartSize < MinPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MinPartSize)
+		assert.False(optimalPartSize > store.MaxPartSize && calcError == nil, "Size %v, %v parts of size %v, lastpart %v: optimalPartSize > MaxPartSize %v, but no error was returned.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxPartSize)
+		assert.False(size%optimalPartSize == 0 && equalparts > store.MaxMultipartParts, "Size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxMultipartParts)
+		assert.False(size%optimalPartSize > 0 && equalparts > store.MaxMultipartParts-1, "Size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxMultipartParts)
+		assert.False(lastpartsize > store.MaxPartSize, "Size %v, %v parts of size %v, lastpart %v: lastpart > MaxPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxPartSize)
+		assert.False(lastpartsize > optimalPartSize, "Size %v, %v parts of size %v, lastpart %v: lastpart > optimalPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, optimalPartSize)
 		if debug {
 			fmt.Printf("Size %v, %v parts of size %v, lastpart %v, does exceed MaxObjectSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, size > store.MaxObjectSize)
 		}
@@ -150,16 +151,16 @@ func TestAllPartSizes(t *testing.T) {
 		t.Errorf("MaxObjectSize %v can never be achieved, as MaxMultipartParts %v and MaxPartSize %v only allow for an upload of %v bytes total.\n", store.MaxObjectSize, store.MaxMultipartParts, store.MaxPartSize, store.MaxMultipartParts*store.MaxPartSize)
 	}
 
-	for size := int64(1); size <= store.MaxObjectSize; size++ {
+	for size := int64(0); size <= store.MaxObjectSize+1; size++ {
 		optimalPartSize, calcError := store.CalcOptimalPartSize(size)
 		equalparts = size / optimalPartSize
 		lastpartsize = size % optimalPartSize
-		assert.False(optimalPartSize < store.MinPartSize, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: optimalPartSize < MinPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MinPartSize))
-		assert.False(optimalPartSize > store.MaxPartSize && calcError == nil, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: optimalPartSize > MaxPartSize %v, but no error was returned.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxPartSize))
-		assert.False(size%optimalPartSize == 0 && equalparts > store.MaxMultipartParts, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxMultipartParts))
-		assert.False(size%optimalPartSize > 0 && equalparts > store.MaxMultipartParts-1, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxMultipartParts))
-		assert.False(lastpartsize > store.MaxPartSize, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: lastpart > MaxPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxPartSize))
-		assert.False(lastpartsize > optimalPartSize, fmt.Sprintf("Size %v, %v parts of size %v, lastpart %v: lastpart > optimalPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, optimalPartSize))
+		assert.False(optimalPartSize < store.MinPartSize, "Size %v, %v parts of size %v, lastpart %v: optimalPartSize < MinPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MinPartSize)
+		assert.False(optimalPartSize > store.MaxPartSize && calcError == nil, "Size %v, %v parts of size %v, lastpart %v: optimalPartSize > MaxPartSize %v, but no error was returned.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxPartSize)
+		assert.False(size%optimalPartSize == 0 && equalparts > store.MaxMultipartParts, "Size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxMultipartParts)
+		assert.False(size%optimalPartSize > 0 && equalparts > store.MaxMultipartParts-1, "Size %v, %v parts of size %v, lastpart %v: more parts than MaxMultipartParts %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxMultipartParts)
+		assert.False(lastpartsize > store.MaxPartSize, "Size %v, %v parts of size %v, lastpart %v: lastpart > MaxPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, store.MaxPartSize)
+		assert.False(lastpartsize > optimalPartSize, "Size %v, %v parts of size %v, lastpart %v: lastpart > optimalPartSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, optimalPartSize)
 		if debug {
 			fmt.Printf("Size %v, %v parts of size %v, lastpart %v, does exceed MaxObjectSize %v.\n", size, equalparts, optimalPartSize, lastpartsize, size > store.MaxObjectSize)
 		}


### PR DESCRIPTION
This is a fix for bug #149.

It has been applied to latest commit in koenvo:s3-large-file-upload-fix branch, not to master and therefore shall be merged after the former has been merged successfully.

So this pull request might be premature, but I wanted to give you a chance to review it early and hope to get some feedback, to get it merged quickly.

My best regards,
Markus