### PR TITLE
GetInfo now properly retrieves info for composed objects

### DIFF
--- a/gcsstore/gcsstore.go
+++ b/gcsstore/gcsstore.go
@@ -126,7 +126,7 @@ func (store GCSStore) GetInfo(id string) (tusd.FileInfo, error) {
 		return info, err
 	}
 
-	prefix := fmt.Sprintf("%s_", id)
+	prefix := fmt.Sprintf("%s", id)
 	filterParams := GCSFilterParams{
 		Bucket: store.Bucket,
 		Prefix: prefix,

--- a/gcsstore/gcsstore_test.go
+++ b/gcsstore/gcsstore_test.go
@@ -103,7 +103,7 @@ func TestGetInfo(t *testing.T) {
 
 	filterParams := gcsstore.GCSFilterParams{
 		Bucket: store.Bucket,
-		Prefix: fmt.Sprintf("%s_", mockID),
+		Prefix: fmt.Sprintf("%s", mockID),
 	}
 
 	mockObjectParams0 := gcsstore.GCSObjectParams{
@@ -230,6 +230,11 @@ func TestFinishUpload(t *testing.T) {
 		Prefix: fmt.Sprintf("%s_", mockID),
 	}
 
+	filterParams2 := gcsstore.GCSFilterParams{
+		Bucket: store.Bucket,
+		Prefix: fmt.Sprintf("%s", mockID),
+	}
+
 	composeParams := gcsstore.GCSComposeParams{
 		Bucket:      store.Bucket,
 		Destination: mockID,
@@ -268,7 +273,7 @@ func TestFinishUpload(t *testing.T) {
 
 	objectParams := gcsstore.GCSObjectParams{
 		Bucket: store.Bucket,
-		ID:     mockID,
+		ID:     fmt.Sprintf("%s", mockID),
 	}
 
 	metadata := map[string]string{
@@ -280,7 +285,7 @@ func TestFinishUpload(t *testing.T) {
 		service.EXPECT().ComposeObjects(composeParams).Return(nil),
 		service.EXPECT().DeleteObjectsWithFilter(filterParams).Return(nil),
 		service.EXPECT().ReadObject(infoParams).Return(r, nil),
-		service.EXPECT().FilterObjects(filterParams).Return(mockPartials, nil),
+		service.EXPECT().FilterObjects(filterParams2).Return(mockPartials, nil),
 		service.EXPECT().GetObjectSize(mockObjectParams0).Return(size, nil),
 		service.EXPECT().GetObjectSize(mockObjectParams1).Return(size, nil),
 		service.EXPECT().GetObjectSize(mockObjectParams2).Return(size, nil),


### PR DESCRIPTION
- This affects the GCSStore only.

Before:
The GCSStore did not search for the proper prefix, which meant that composed files were not seen and always returned 0 for `Upload-Offset` for completed uploads.

Now:
GCSStore checks for all files matching the hash, including completed files and the info file. 

Specifics: 
Before, when an object was composed and finished uploading, it took the filename of `<RANDOM_HASH>`, while tusd used the prefix of `<RANDOM_HASH>_`, resulting in it not finding any files, and stating the uploaded file did not exist, resulting in an `Upload-Offset` of `0`. This PR now checks the bucket for all files with the prefix of `<RANDOM_HASH>`, which now accounts for composed files. 

cc:
@devonbalicki @vayam 