### PR TITLE
Log hooks to stdout

### DIFF
--- a/cmd/tusd/cli/hooks.go
+++ b/cmd/tusd/cli/hooks.go
@@ -70,16 +70,16 @@ func invokeHook(typ HookType, info tusd.FileInfo) {
 func invokeHookSync(typ HookType, info tusd.FileInfo, captureOutput bool) ([]byte, error) {
 	switch typ {
 	case HookPostFinish:
-		logEv("UploadFinished", "id", info.ID, "size", strconv.FormatInt(info.Size, 10))
+		logEv(stdout, "UploadFinished", "id", info.ID, "size", strconv.FormatInt(info.Size, 10))
 	case HookPostTerminate:
-		logEv("UploadTerminated", "id", info.ID)
+		logEv(stdout, "UploadTerminated", "id", info.ID)
 	}
 
 	if !Flags.FileHooksInstalled && !Flags.HttpHooksInstalled {
 		return nil, nil
 	}
 	name := string(typ)
-	logEv("HookInvocationStart", "type", name, "id", info.ID)
+	logEv(stdout, "HookInvocationStart", "type", name, "id", info.ID)
 
 	output := []byte{}
 	err := error(nil)
@@ -93,9 +93,9 @@ func invokeHookSync(typ HookType, info tusd.FileInfo, captureOutput bool) ([]byt
 	}
 
 	if err != nil {
-		logEv("HookInvocationError", "type", string(typ), "id", info.ID, "error", err.Error())
+		logEv(stderr, "HookInvocationError", "type", string(typ), "id", info.ID, "error", err.Error())
 	} else {
-		logEv("HookInvocationFinish", "type", string(typ), "id", info.ID)
+		logEv(stdout, "HookInvocationFinish", "type", string(typ), "id", info.ID)
 	}
 
 	return output, err

--- a/cmd/tusd/cli/log.go
+++ b/cmd/tusd/cli/log.go
@@ -10,6 +10,6 @@ import (
 var stdout = log.New(os.Stdout, "[tusd] ", 0)
 var stderr = log.New(os.Stderr, "[tusd] ", 0)
 
-func logEv(eventName string, details ...string) {
-	tusd.LogEvent(stderr, eventName, details...)
+func logEv(logOutput *log.Logger, eventName string, details ...string) {
+	tusd.LogEvent(logOutput, eventName, details...)
 }


### PR DESCRIPTION
Hooks currently get logged into stderr, which (if you're running tus in GKE) result in hook logs being erroneously reported as errors. This PR sets hook logs to go to stdout. 

It's also possible that this should be a user configurable setting, I'm open to suggestions on how this should be implemented. 