### PR TITLE
Handle GCS object not found error

### DIFF
--- a/gcsstore/gcsservice.go
+++ b/gcsstore/gcsservice.go
@@ -13,8 +13,9 @@ import (
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 
-	"github.com/vimeo/go-util/crc32combine"
 	"hash/crc32"
+
+	"github.com/vimeo/go-util/crc32combine"
 )
 
 type GCSObjectParams struct {
@@ -260,7 +261,7 @@ func (service *GCSService) GetObjectAttrs(params GCSObjectParams) (*storage.Obje
 
 }
 
-// ReadObject reaads a GCSObjectParams, returning a GCSReader object if successful, and an error otherwise
+// ReadObject reads a GCSObjectParams, returning a GCSReader object if successful, and an error otherwise
 func (service *GCSService) ReadObject(params GCSObjectParams) (GCSReader, error) {
 	r, err := service.Client.Bucket(params.Bucket).Object(params.ID).NewReader(service.Ctx)
 	if err != nil {

--- a/gcsstore/gcsstore.go
+++ b/gcsstore/gcsstore.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 
+	"cloud.google.com/go/storage"
 	"github.com/tus/tusd"
 	"github.com/tus/tusd/uid"
 )
@@ -113,6 +114,9 @@ func (store GCSStore) GetInfo(id string) (tusd.FileInfo, error) {
 
 	r, err := store.Service.ReadObject(params)
 	if err != nil {
+		if err == storage.ErrObjectNotExist {
+			return info, tusd.ErrNotFound
+		}
 		return info, err
 	}
 


### PR DESCRIPTION
This makes the Google Cloud Storage store consistent with the S3 store implementation by making `GetInfo` return `ErrNotFound` when the object is not found.

This also makes the HEAD request return `404` instead of `500` when attempting to get the upload status of a non-existent file stored on GCS.