### PR TITLE
Allow AWS-SDK to handle gathering credentials

### DIFF
--- a/cmd/tusd/cli/composer.go
+++ b/cmd/tusd/cli/composer.go
@@ -11,7 +11,6 @@ import (
 	"github.com/tus/tusd/gcsstore"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
@@ -33,10 +32,9 @@ func CreateComposer() {
 			s3Config = s3Config.WithEndpoint(Flags.S3Endpoint).WithS3ForcePathStyle(true)
 		}
 
-		// Derive credentials from AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID and
-		// AWS_REGION environment variables.
-		s3Config = s3Config.WithCredentials(credentials.NewEnvCredentials())
-		store := s3store.New(Flags.S3Bucket, s3.New(session.New(), s3Config))
+		// Derive credentials from default credential chain (env, shared, ec2 instance role)
+		// as per https://github.com/aws/aws-sdk-go#configuring-credentials
+		store := s3store.New(Flags.S3Bucket, s3.New(session.Must(session.NewSession()), s3Config))
 		store.UseIn(Composer)
 
 		locker := memorylocker.New()


### PR DESCRIPTION
Previously, you could _only_ use environment variables.   This change enables the SDK to handle credentials according to its standard "credential chain".  Per the [docs](https://github.com/aws/aws-sdk-go#configuring-credentials):

> By default the SDK will source credentials automatically from its default credential chain. See the session package for more information on this chain, and how to configure it. The common items in the credential chain are the following:
> * Environment Credentials - Set of environment variables that are useful when sub processes are created for specific roles.
> * Shared Credentials file (~/.aws/credentials) - This file stores your credentials based on a profile name and is useful for local development.
> * EC2 Instance Role Credentials - Use EC2 Instance Role to assign credentials to application running on an EC2 instance. This removes the need to manage credential files in production.

From my testing, this change should not adversely affect existing installs, since the Environment variables will still work.