### PR TITLE
Updates uploadLength logic in PatchFile

### DIFF
--- a/unrouted_handler.go
+++ b/unrouted_handler.go
@@ -470,7 +470,7 @@ func (handler *UnroutedHandler) PatchFile(w http.ResponseWriter, r *http.Request
 			return
 		}
 		uploadLength, err := strconv.ParseInt(r.Header.Get("Upload-Length"), 10, 64)
-		if err != nil || uploadLength < 0 || uploadLength < info.Offset || uploadLength > handler.config.MaxSize {
+		if err != nil || uploadLength < 0 || uploadLength < info.Offset || (handler.config.MaxSize > 0 && uploadLength > handler.config.MaxSize) {
 			handler.sendError(w, r, ErrInvalidUploadLength)
 			return
 		}


### PR DESCRIPTION
There is currently an issue wherein PATCH-ing a file which had `Upload-Defer-Length` with `Upload-Length` only results in error. I believe it's the case that the `uploadLength` is checked against the `MaxSize` in the handler, which by default is `0.00` (i.e. no limit). This should cover the default case.