### PR TITLE
Add documentation about HTTP Hooks status code

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -99,6 +99,9 @@ $ tusd --hooks-http http://localhost:8081/write
 
 Note that the URL must include the `http://` prefix!
 
+In case of a blocking hook, HTTP Status Code 400 or greater tells tusd to reject the request (in the same way as non-zero exit code for File Hooks). See also [issue #170](https://github.com/tus/tusd/issues/170) regarding further improvements.
+
+
 ### Usage
 
 Tusd will issue a `POST` request to the specified URL endpoint, specifying the hook name, such as pre-create or post-finish, in the `Hook-Name` header and following body:


### PR DESCRIPTION
HTTP Status Code meaning was missed.

Source code reference: https://github.com/tus/tusd/blob/311cdf253e50a21b12c0cae094ed0c2d20c66d5c/cmd/tusd/cli/hooks.go#L137