### PR TITLE
Add support for concurrent GetObjectSize requests

### DIFF
--- a/gcsstore/gcsservice_test.go
+++ b/gcsstore/gcsservice_test.go
@@ -2,7 +2,7 @@ package gcsstore_test
 
 import (
 	"bytes"
-	"context"
+	"golang.org/x/net/context"
 	"testing"
 
 	"gopkg.in/h2non/gock.v1"
@@ -47,10 +47,9 @@ func TestGetObjectSize(t *testing.T) {
 
 	service := GCSService{
 		Client: client,
-		Ctx:    ctx,
 	}
 
-	size, err := service.GetObjectSize(GCSObjectParams{
+	size, err := service.GetObjectSize(ctx, GCSObjectParams{
 		Bucket: "test-bucket",
 		ID:     "test-name",
 	})
@@ -94,10 +93,9 @@ func TestDeleteObjectWithFilter(t *testing.T) {
 
 	service := GCSService{
 		Client: client,
-		Ctx:    ctx,
 	}
 
-	err = service.DeleteObjectsWithFilter(GCSFilterParams{
+	err = service.DeleteObjectsWithFilter(ctx, GCSFilterParams{
 		Bucket: "test-bucket",
 		Prefix: "test-prefix",
 	})
@@ -180,10 +178,9 @@ func TestComposeObjects(t *testing.T) {
 
 	service := GCSService{
 		Client: client,
-		Ctx:    ctx,
 	}
 
-	err = service.ComposeObjects(GCSComposeParams{
+	err = service.ComposeObjects(ctx, GCSComposeParams{
 		Bucket:      "test-bucket",
 		Sources:     []string{"test1", "test2", "test3"},
 		Destination: "test_all",
@@ -222,10 +219,9 @@ func TestGetObjectAttrs(t *testing.T) {
 
 	service := GCSService{
 		Client: client,
-		Ctx:    ctx,
 	}
 
-	attrs, err := service.GetObjectAttrs(GCSObjectParams{
+	attrs, err := service.GetObjectAttrs(ctx, GCSObjectParams{
 		Bucket: "test-bucket",
 		ID:     "test-name",
 	})
@@ -266,10 +262,9 @@ func TestReadObject(t *testing.T) {
 
 	service := GCSService{
 		Client: client,
-		Ctx:    ctx,
 	}
 
-	reader, err := service.ReadObject(GCSObjectParams{
+	reader, err := service.ReadObject(ctx, GCSObjectParams{
 		Bucket: "test-bucket",
 		ID:     "test-name",
 	})
@@ -304,10 +299,9 @@ func TestSetObjectMetadata(t *testing.T) {
 
 	service := GCSService{
 		Client: client,
-		Ctx:    ctx,
 	}
 
-	err = service.SetObjectMetadata(GCSObjectParams{
+	err = service.SetObjectMetadata(ctx, GCSObjectParams{
 		Bucket: "test-bucket",
 		ID:     "test-name",
 	}, map[string]string{"test": "metadata", "fake": "test"})
@@ -343,10 +337,9 @@ func TestDeleteObject(t *testing.T) {
 
 	service := GCSService{
 		Client: client,
-		Ctx:    ctx,
 	}
 
-	err = service.DeleteObject(GCSObjectParams{
+	err = service.DeleteObject(ctx, GCSObjectParams{
 		Bucket: "test-bucket",
 		ID:     "test-name",
 	})
@@ -376,12 +369,11 @@ func TestWriteObject(t *testing.T) {
 
 	service := GCSService{
 		Client: client,
-		Ctx:    ctx,
 	}
 
 	reader := bytes.NewReader([]byte{1})
 
-	size, err := service.WriteObject(GCSObjectParams{
+	size, err := service.WriteObject(ctx, GCSObjectParams{
 		Bucket: "test-bucket",
 		ID:     "test-name",
 	}, reader)
@@ -428,10 +420,9 @@ func TestComposeFrom(t *testing.T) {
 
 	service := GCSService{
 		Client: client,
-		Ctx:    ctx,
 	}
 
-	crc, err := service.ComposeFrom([]*storage.ObjectHandle{client.Bucket("test-bucket").Object("my-object")}, GCSObjectParams{
+	crc, err := service.ComposeFrom(ctx, []*storage.ObjectHandle{client.Bucket("test-bucket").Object("my-object")}, GCSObjectParams{
 		Bucket: "test-bucket",
 		ID:     "my-object",
 	}, "text")
@@ -478,10 +469,9 @@ func TestFilterObject(t *testing.T) {
 
 	service := GCSService{
 		Client: client,
-		Ctx:    ctx,
 	}
 
-	objects, err := service.FilterObjects(GCSFilterParams{
+	objects, err := service.FilterObjects(ctx, GCSFilterParams{
 		Bucket: "test-bucket",
 		Prefix: "test-prefix",
 	})

--- a/gcsstore/gcsstore_mock_test.go
+++ b/gcsstore/gcsstore_mock_test.go
@@ -4,6 +4,7 @@
 package gcsstore_test
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	gcsstore "github.com/tus/tusd/gcsstore"
 	io "io"
@@ -102,86 +103,86 @@ func (_m *MockGCSAPI) EXPECT() *_MockGCSAPIRecorder {
 	return _m.recorder
 }
 
-func (_m *MockGCSAPI) ComposeObjects(_param0 gcsstore.GCSComposeParams) error {
-	ret := _m.ctrl.Call(_m, "ComposeObjects", _param0)
+func (_m *MockGCSAPI) ComposeObjects(_param0 context.Context, _param1 gcsstore.GCSComposeParams) error {
+	ret := _m.ctrl.Call(_m, "ComposeObjects", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockGCSAPIRecorder) ComposeObjects(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ComposeObjects", arg0)
+func (_mr *_MockGCSAPIRecorder) ComposeObjects(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ComposeObjects", arg0, arg1)
 }
 
-func (_m *MockGCSAPI) DeleteObject(_param0 gcsstore.GCSObjectParams) error {
-	ret := _m.ctrl.Call(_m, "DeleteObject", _param0)
+func (_m *MockGCSAPI) DeleteObject(_param0 context.Context, _param1 gcsstore.GCSObjectParams) error {
+	ret := _m.ctrl.Call(_m, "DeleteObject", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockGCSAPIRecorder) DeleteObject(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteObject", arg0)
+func (_mr *_MockGCSAPIRecorder) DeleteObject(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteObject", arg0, arg1)
 }
 
-func (_m *MockGCSAPI) DeleteObjectsWithFilter(_param0 gcsstore.GCSFilterParams) error {
-	ret := _m.ctrl.Call(_m, "DeleteObjectsWithFilter", _param0)
+func (_m *MockGCSAPI) DeleteObjectsWithFilter(_param0 context.Context, _param1 gcsstore.GCSFilterParams) error {
+	ret := _m.ctrl.Call(_m, "DeleteObjectsWithFilter", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockGCSAPIRecorder) DeleteObjectsWithFilter(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteObjectsWithFilter", arg0)
+func (_mr *_MockGCSAPIRecorder) DeleteObjectsWithFilter(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteObjectsWithFilter", arg0, arg1)
 }
 
-func (_m *MockGCSAPI) FilterObjects(_param0 gcsstore.GCSFilterParams) ([]string, error) {
-	ret := _m.ctrl.Call(_m, "FilterObjects", _param0)
+func (_m *MockGCSAPI) FilterObjects(_param0 context.Context, _param1 gcsstore.GCSFilterParams) ([]string, error) {
+	ret := _m.ctrl.Call(_m, "FilterObjects", _param0, _param1)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockGCSAPIRecorder) FilterObjects(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FilterObjects", arg0)
+func (_mr *_MockGCSAPIRecorder) FilterObjects(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FilterObjects", arg0, arg1)
 }
 
-func (_m *MockGCSAPI) GetObjectSize(_param0 gcsstore.GCSObjectParams) (int64, error) {
-	ret := _m.ctrl.Call(_m, "GetObjectSize", _param0)
+func (_m *MockGCSAPI) GetObjectSize(_param0 context.Context, _param1 gcsstore.GCSObjectParams) (int64, error) {
+	ret := _m.ctrl.Call(_m, "GetObjectSize", _param0, _param1)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockGCSAPIRecorder) GetObjectSize(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetObjectSize", arg0)
+func (_mr *_MockGCSAPIRecorder) GetObjectSize(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetObjectSize", arg0, arg1)
 }
 
-func (_m *MockGCSAPI) ReadObject(_param0 gcsstore.GCSObjectParams) (gcsstore.GCSReader, error) {
-	ret := _m.ctrl.Call(_m, "ReadObject", _param0)
+func (_m *MockGCSAPI) ReadObject(_param0 context.Context, _param1 gcsstore.GCSObjectParams) (gcsstore.GCSReader, error) {
+	ret := _m.ctrl.Call(_m, "ReadObject", _param0, _param1)
 	ret0, _ := ret[0].(gcsstore.GCSReader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockGCSAPIRecorder) ReadObject(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadObject", arg0)
+func (_mr *_MockGCSAPIRecorder) ReadObject(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadObject", arg0, arg1)
 }
 
-func (_m *MockGCSAPI) SetObjectMetadata(_param0 gcsstore.GCSObjectParams, _param1 map[string]string) error {
-	ret := _m.ctrl.Call(_m, "SetObjectMetadata", _param0, _param1)
+func (_m *MockGCSAPI) SetObjectMetadata(_param0 context.Context, _param1 gcsstore.GCSObjectParams, _param2 map[string]string) error {
+	ret := _m.ctrl.Call(_m, "SetObjectMetadata", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockGCSAPIRecorder) SetObjectMetadata(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetObjectMetadata", arg0, arg1)
+func (_mr *_MockGCSAPIRecorder) SetObjectMetadata(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetObjectMetadata", arg0, arg1, arg2)
 }
 
-func (_m *MockGCSAPI) WriteObject(_param0 gcsstore.GCSObjectParams, _param1 io.Reader) (int64, error) {
-	ret := _m.ctrl.Call(_m, "WriteObject", _param0, _param1)
+func (_m *MockGCSAPI) WriteObject(_param0 context.Context, _param1 gcsstore.GCSObjectParams, _param2 io.Reader) (int64, error) {
+	ret := _m.ctrl.Call(_m, "WriteObject", _param0, _param1, _param2)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockGCSAPIRecorder) WriteObject(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteObject", arg0, arg1)
+func (_mr *_MockGCSAPIRecorder) WriteObject(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteObject", arg0, arg1, arg2)
 }


### PR DESCRIPTION
In production on Vimeo we were seeing an issue where requests to calculate the current offset of an upload were taking an incredibly long time. We discovered that this was only happening for uploads that had a large number of composable parts. A head request to a file with >200 parts was taking over a minute to respond. 

In order to speed this process up, this PR changes the `GetObjectSize` calls in the store's `GetInfo` method to run concurrently. We limit this concurrency with a semaphore that allows at most 32 goroutines to be working on this task at a time. 

This performance improvement required that we pass context to `GCSService` rather than using an internal and shared one. The reason being that if one `GetObjectSize` call in a goroutine fails, we need a way to cancel all subsequent calls. 

cc @justinruggles @vayam @devonbalicki @erunion