### PR TITLE
etcd3 Locker: First pass

### DIFF
--- a/.scripts/test_all.sh
+++ b/.scripts/test_all.sh
@@ -5,7 +5,7 @@ set -e
 # Find all packages containing Go source code inside the current directory
 packages=$(find ./ -maxdepth 2 -name '*.go' -printf '%h\n' | sort | uniq)
 
-# The consul package only supports Go1.8+ and therefore we will only run the
+# The consul package only supports Go1.10+ and therefore we will only run the
 # corresponding tests on these versions.
 goversion=$(go version)
 if [[ "$goversion" == *"go1.5"* ]] ||
@@ -24,6 +24,10 @@ if [[ "$goversion" == *"go1.5"* ]] ||
 else
   # Install the Consul packages which are not vendored.
   go get -u github.com/hashicorp/consul/...
+
+  # Install the etcd packages which are not vendored.
+  go get -u github.com/coreos/etcd
+  go get -u github.com/mwitkow/go-etcd-harness
 fi
 
 # Install the AWS SDK and Prometheus client which is explicitly not vendored

--- a/.scripts/test_all.sh
+++ b/.scripts/test_all.sh
@@ -28,6 +28,7 @@ fi
 
 install_etcd_pkgs() {
   go get -u github.com/coreos/etcd
+  go get -u github.com/gogo/protobuf/gogoproto
   go get -u google.golang.org/grpc
   go get -u github.com/coreos/go-semver
   go get -u github.com/ugorji/go/codec

--- a/.scripts/test_all.sh
+++ b/.scripts/test_all.sh
@@ -42,8 +42,6 @@ if [[ "$goversion" == *"go1.5"* ]] ||
 else
   # Install the etcd packages which are not vendored.
   install_etcd_pkgs
-  # use release 3.3 as master branches are not stable for etcd
-  (cd ../../coreos/etcd && git fetch origin && git checkout release-3.3)
 fi
 
 # Install the AWS SDK and Prometheus client which is explicitly not vendored

--- a/.scripts/test_all.sh
+++ b/.scripts/test_all.sh
@@ -27,11 +27,7 @@ else
 fi
 
 install_etcd_pkgs() {
-  go get -u github.com/coreos/etcd
-  go get -u github.com/gogo/protobuf/gogoproto
-  go get -u google.golang.org/grpc
-  go get -u github.com/coreos/go-semver
-  go get -u github.com/ugorji/go/codec
+  go get -u go.etcd.io/etcd/clientv3
   go get -u github.com/mwitkow/go-etcd-harness
 }
 

--- a/.scripts/test_all.sh
+++ b/.scripts/test_all.sh
@@ -21,22 +21,32 @@ if [[ "$goversion" == *"go1.5"* ]] ||
 
   echo "Skipping tests requiring GCSStore, which is not supported on $goversion"
   packages=$(echo "$packages" | sed '/gcsstore/d')
-
-  echo "Skipping tests requiring etcd3locker, which is not supported on $goversion"
-  packages=$(echo "$packages" | sed '/etcd3locker/d')
 else
   # Install the Consul packages which are not vendored.
   go get -u github.com/hashicorp/consul/...
+fi
 
-  # Install the etcd packages which are not vendored.
+install_etcd_pkgs() {
   go get -u github.com/coreos/etcd
-  # use release 3.3 as master branches are not stable for etcd
-  (cd ../../coreos/etcd && git fetch origin && git checkout release-3.3)
   go get -u google.golang.org/grpc
   go get -u github.com/coreos/go-semver
   go get -u github.com/ugorji/go/codec
   go get -u github.com/mwitkow/go-etcd-harness
+}
 
+# The etcd 3.3.x package only supports Go1.9+ and therefore
+# we will only run the corresponding tests on these versions.
+if [[ "$goversion" == *"go1.5"* ]] ||
+   [[ "$goversion" == *"go1.6"* ]] ||
+   [[ "$goversion" == *"go1.7"* ]] ||
+   [[ "$goversion" == *"go1.8"* ]]; then
+  echo "Skipping tests requiring etcd3locker, which is not supported on $goversion"
+  packages=$(echo "$packages" | sed '/etcd3locker/d')
+else
+  # Install the etcd packages which are not vendored.
+  install_etcd_pkgs
+  # use release 3.3 as master branches are not stable for etcd
+  (cd ../../coreos/etcd && git fetch origin && git checkout release-3.3)
 fi
 
 # Install the AWS SDK and Prometheus client which is explicitly not vendored

--- a/.scripts/test_all.sh
+++ b/.scripts/test_all.sh
@@ -21,13 +21,22 @@ if [[ "$goversion" == *"go1.5"* ]] ||
 
   echo "Skipping tests requiring GCSStore, which is not supported on $goversion"
   packages=$(echo "$packages" | sed '/gcsstore/d')
+
+  echo "Skipping tests requiring etcd3locker, which is not supported on $goversion"
+  packages=$(echo "$packages" | sed '/etcd3locker/d')
 else
   # Install the Consul packages which are not vendored.
   go get -u github.com/hashicorp/consul/...
 
   # Install the etcd packages which are not vendored.
   go get -u github.com/coreos/etcd
+  # use release 3.3 as master branches are not stable for etcd
+  (cd ../../coreos/etcd && git fetch origin && git checkout release-3.3)
+  go get -u google.golang.org/grpc
+  go get -u github.com/coreos/go-semver
+  go get -u github.com/ugorji/go/codec
   go get -u github.com/mwitkow/go-etcd-harness
+
 fi
 
 # Install the AWS SDK and Prometheus client which is explicitly not vendored

--- a/.scripts/test_all.sh
+++ b/.scripts/test_all.sh
@@ -27,8 +27,12 @@ else
 fi
 
 install_etcd_pkgs() {
+  ETCD_VERSION="3.3.10"
   go get -u go.etcd.io/etcd/clientv3
   go get -u github.com/chen-anders/go-etcd-harness
+  wget -q -O /tmp/etcd.tar.gz "https://github.com/etcd-io/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-amd64.tar.gz"
+  tar xvzf /tmp/etcd.tar.gz -C /tmp
+  export PATH="$PATH:/tmp/etcd-v$ETCD_VERSION-linux-amd64"
 }
 
 # The etcd 3.3.x package only supports Go1.9+ and therefore

--- a/.scripts/test_all.sh
+++ b/.scripts/test_all.sh
@@ -28,7 +28,7 @@ fi
 
 install_etcd_pkgs() {
   go get -u go.etcd.io/etcd/clientv3
-  go get -u github.com/mwitkow/go-etcd-harness
+  go get -u github.com/chen-anders/go-etcd-harness
 }
 
 # The etcd 3.3.x package only supports Go1.9+ and therefore

--- a/etcd3locker/lock.go
+++ b/etcd3locker/lock.go
@@ -1,0 +1,47 @@
+// Tested on etcd 3.1+
+package etcd3locker
+
+import (
+	"context"
+	"time"
+
+	"github.com/coreos/etcd/clientv3/concurrency"
+	"github.com/tus/tusd"
+)
+
+type Etcd3Lock struct {
+	Id      string
+	Mutex   *concurrency.Mutex
+	Session *concurrency.Session
+}
+
+func NewEtcd3Lock(session *concurrency.Session, id string) *Etcd3Lock {
+	return &Etcd3Lock{
+		Mutex:   concurrency.NewMutex(session, id),
+		Session: session,
+	}
+}
+
+func (lock *Etcd3Lock) Acquire() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// this is a blocking call; if we receive DeadlineExceeded
+	// the lock is most likely already taken
+	if err := lock.Mutex.Lock(ctx); err != nil {
+		if err == context.DeadlineExceeded {
+			return tusd.ErrFileLocked
+		} else {
+			return err
+		}
+	}
+	return nil
+}
+
+func (lock *Etcd3Lock) Release() error {
+	return lock.Mutex.Unlock(context.Background())
+}
+
+func (lock *Etcd3Lock) CloseSession() error {
+	return lock.Session.Close()
+}

--- a/etcd3locker/lock.go
+++ b/etcd3locker/lock.go
@@ -9,20 +9,20 @@ import (
 	"github.com/tus/tusd"
 )
 
-type Etcd3Lock struct {
+type etcd3Lock struct {
 	Id      string
 	Mutex   *concurrency.Mutex
 	Session *concurrency.Session
 }
 
-func NewEtcd3Lock(session *concurrency.Session, id string) *Etcd3Lock {
-	return &Etcd3Lock{
+func newEtcd3Lock(session *concurrency.Session, id string) *etcd3Lock {
+	return &etcd3Lock{
 		Mutex:   concurrency.NewMutex(session, id),
 		Session: session,
 	}
 }
 
-func (lock *Etcd3Lock) Acquire() error {
+func (lock *etcd3Lock) Acquire() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -38,10 +38,10 @@ func (lock *Etcd3Lock) Acquire() error {
 	return nil
 }
 
-func (lock *Etcd3Lock) Release() error {
+func (lock *etcd3Lock) Release() error {
 	return lock.Mutex.Unlock(context.Background())
 }
 
-func (lock *Etcd3Lock) CloseSession() error {
+func (lock *etcd3Lock) CloseSession() error {
 	return lock.Session.Close()
 }

--- a/etcd3locker/lock.go
+++ b/etcd3locker/lock.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/coreos/etcd/clientv3/concurrency"
+	"go.etcd.io/etcd/clientv3/concurrency"
 	"github.com/tus/tusd"
 )
 

--- a/etcd3locker/lock.go
+++ b/etcd3locker/lock.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"time"
 
-	"go.etcd.io/etcd/clientv3/concurrency"
 	"github.com/tus/tusd"
+	"go.etcd.io/etcd/clientv3/concurrency"
 )
 
 type etcd3Lock struct {

--- a/etcd3locker/locker.go
+++ b/etcd3locker/locker.go
@@ -1,0 +1,120 @@
+// Tested on etcd 3.1/3.2/3.3
+package etcd3locker
+
+import (
+	"context"
+	"errors"
+	"log"
+	"strings"
+	"sync"
+
+	etcd3 "github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
+	"github.com/tus/tusd"
+)
+
+var (
+	ErrLockNotHeld = errors.New("Lock not held")
+	DefaultTtl     = int64(60)
+)
+
+type Etcd3Locker struct {
+	// etcd3 client session
+	Client *etcd3.Client
+
+	// locks is used for storing Etcd3Locks before they are
+	// unlocked. If you want to release a lock, you need the same locker
+	// instance and therefore we need to save them temporarily.
+	locks  map[string]*Etcd3Lock
+	mutex  sync.Mutex
+	prefix string
+}
+
+// New constructs a new locker using the provided client.
+func New(client *etcd3.Client) (*Etcd3Locker, error) {
+	return NewWithPrefix(client, "/tusd")
+}
+
+// This method may be used if a different prefix is required for multi-tenant etcd clusters
+func NewWithPrefix(client *etcd3.Client, prefix string) (*Etcd3Locker, error) {
+	locksMap := map[string]*Etcd3Lock{}
+
+	if !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
+	}
+
+	return &Etcd3Locker{Client: client, prefix: prefix, locks: locksMap, mutex: sync.Mutex{}}, nil
+}
+
+// UseIn adds this locker to the passed composer.
+func (locker *Etcd3Locker) UseIn(composer *tusd.StoreComposer) {
+	composer.UseLocker(locker)
+}
+
+// LockUpload tries to obtain the exclusive lock.
+func (locker *Etcd3Locker) LockUpload(id string) error {
+	session, err := locker.createSession()
+	if err != nil {
+		return err
+	}
+
+	lock := NewEtcd3Lock(session, locker.getId(id))
+
+	err = lock.Acquire()
+	if err != nil {
+		return err
+	}
+
+	locker.mutex.Lock()
+	defer locker.mutex.Unlock()
+	// Only add the lock to our list if the acquire was successful and no error appeared.
+	locker.locks[locker.getId(id)] = lock
+
+	return nil
+}
+
+// UnlockUpload releases a lock. If no such lock exists, no error will be returned.
+func (locker *Etcd3Locker) UnlockUpload(id string) error {
+	locker.mutex.Lock()
+	defer locker.mutex.Unlock()
+
+	// Complain if no lock has been found. This can only happen if LockUpload
+	// has not been invoked before or UnlockUpload multiple times.
+	lock, ok := locker.locks[locker.getId(id)]
+	if !ok {
+		return ErrLockNotHeld
+	}
+
+	err := lock.Release()
+	if err != nil {
+		return err
+	}
+
+	defer delete(locker.locks, locker.getId(id))
+	return lock.CloseSession()
+}
+
+func (locker *Etcd3Locker) createSession() (*concurrency.Session, error) {
+	lease, err := locker.Client.Grant(context.TODO(), DefaultTtl)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Keep lease alive until this process dies
+	ch, keepAliveErr := locker.Client.KeepAlive(context.TODO(), lease.ID)
+	if keepAliveErr != nil {
+		log.Fatal(keepAliveErr)
+	}
+
+	go func() {
+		for _ = range ch {
+			// do nothing
+		}
+	}()
+
+	return concurrency.NewSession(locker.Client, concurrency.WithLease(lease.ID))
+}
+
+func (locker *Etcd3Locker) getId(id string) string {
+	return locker.prefix + id
+}

--- a/etcd3locker/locker.go
+++ b/etcd3locker/locker.go
@@ -4,7 +4,6 @@ package etcd3locker
 import (
 	"context"
 	"errors"
-	"log"
 	"strings"
 	"sync"
 
@@ -97,13 +96,13 @@ func (locker *etcd3Locker) UnlockUpload(id string) error {
 func (locker *etcd3Locker) createSession() (*concurrency.Session, error) {
 	lease, err := locker.Client.Grant(context.Background(), DefaultTtl)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	// Keep lease alive until this process dies
 	ch, keepAliveErr := locker.Client.KeepAlive(context.Background(), lease.ID)
 	if keepAliveErr != nil {
-		log.Fatal(keepAliveErr)
+		return nil, keepAliveErr
 	}
 
 	go func() {

--- a/etcd3locker/locker.go
+++ b/etcd3locker/locker.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	etcd3 "github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/clientv3/concurrency"
+	etcd3 "go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3/concurrency"
 	"github.com/tus/tusd"
 )
 

--- a/etcd3locker/locker.go
+++ b/etcd3locker/locker.go
@@ -1,4 +1,45 @@
+// Package etcd3locker provides a locking mechanism using an etcd3 cluster
+//
+// To initialize a locker, a pre-existing connected etcd3 client must be present
+//
+//		client, err := clientv3.New(clientv3.Config{
+//				Endpoints:   []string{harness.Endpoint},
+//				DialTimeout: 5 * time.Second,
+//		})
+//
+//	For the most basic locker (e.g. non-shared etcd3 cluster / use default TTLs),
+//	a locker can be instantiated like the following:
+//
+//		locker, err := etcd3locker.New(client)
+//		if err != nil {
+//				return nil, fmt.Errorf("Failed to create etcd locker: %v", err.Error())
+//		}
+//
+//	The locker will need to be included in composer that is used by tusd:
+//
+//		composer := tusd.NewStoreComposer()
+//		locker.UseIn(composer)
+//
+//	For a shared etcd3 cluster, you may want to modify the prefix that etcd3locker uses:
+//
+//		locker, err := etcd3locker.NewWithPrefix(client, "my-prefix")
+//		if err != nil {
+//				return nil, fmt.Errorf("Failed to create etcd locker: %v", err.Error())
+//		}
+//
+//
+//	For full control over all options, an etcd3.LockerOptions may be passed into
+//	etcd3.NewWithLockerOptions like the following example:
+//
+//		ttl := 15 // seconds
+//		options := etcd3locker.NewLockerOptions(ttl, "my-prefix")
+//		locker, err := etcd3locker.NewWithLockerOptions(client, options)
+//		if err != nil {
+//				return nil, fmt.Errorf("Failed to create etcd locker: %v", err.Error())
+//		}
+//
 // Tested on etcd 3.1/3.2/3.3
+//
 package etcd3locker
 
 import (
@@ -6,9 +47,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tus/tusd"
 	etcd3 "go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/concurrency"
-	"github.com/tus/tusd"
 )
 
 var (

--- a/etcd3locker/locker.go
+++ b/etcd3locker/locker.go
@@ -42,7 +42,7 @@ func NewWithPrefix(client *etcd3.Client, prefix string) (*etcd3Locker, error) {
 }
 
 // This method may be used if we want control over both prefix/session TTLs. This is used for testing in particular.
-func NewWithLockerOptions(client *etcd3.Client, opts *LockerOptions) (*etcd3Locker, error) {
+func NewWithLockerOptions(client *etcd3.Client, opts LockerOptions) (*etcd3Locker, error) {
 	locksMap := map[string]*etcd3Lock{}
 	return &etcd3Locker{Client: client, prefix: opts.Prefix(), sessionTimeout: opts.Timeout(), locks: locksMap, mutex: sync.Mutex{}}, nil
 }

--- a/etcd3locker/locker.go
+++ b/etcd3locker/locker.go
@@ -95,13 +95,13 @@ func (locker *etcd3Locker) UnlockUpload(id string) error {
 }
 
 func (locker *etcd3Locker) createSession() (*concurrency.Session, error) {
-	lease, err := locker.Client.Grant(context.TODO(), DefaultTtl)
+	lease, err := locker.Client.Grant(context.Background(), DefaultTtl)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Keep lease alive until this process dies
-	ch, keepAliveErr := locker.Client.KeepAlive(context.TODO(), lease.ID)
+	ch, keepAliveErr := locker.Client.KeepAlive(context.Background(), lease.ID)
 	if keepAliveErr != nil {
 		log.Fatal(keepAliveErr)
 	}

--- a/etcd3locker/locker_options.go
+++ b/etcd3locker/locker_options.go
@@ -1,0 +1,58 @@
+package etcd3locker
+
+import (
+	"strings"
+)
+
+var (
+	DefaultTtl    = 60
+	DefaultPrefix = "/tusd"
+)
+
+type LockerOptions struct {
+	timeoutSeconds int
+	prefix         string
+}
+
+func DefaultLockerOptions() *LockerOptions {
+	return &LockerOptions{
+		timeoutSeconds: 60,
+		prefix:         "/tusd",
+	}
+}
+
+func NewLockerOptions(timeout int, prefix string) *LockerOptions {
+	return &LockerOptions{
+		timeoutSeconds: timeout,
+		prefix:         prefix,
+	}
+}
+
+func (l *LockerOptions) Timeout() int {
+	if l.timeoutSeconds == 0 {
+		return DefaultTtl
+	} else {
+		return l.timeoutSeconds
+	}
+}
+
+func (l *LockerOptions) Prefix() string {
+	prefix := l.prefix
+	if !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
+	}
+
+	if prefix == "" {
+		return DefaultPrefix
+	} else {
+		return prefix
+	}
+}
+
+func (l *LockerOptions) SetTimeout(timeout int) {
+	l.timeoutSeconds = timeout
+}
+
+func (l *LockerOptions) SetPrefix(prefix string) {
+	l.prefix = prefix
+}

--- a/etcd3locker/locker_options.go
+++ b/etcd3locker/locker_options.go
@@ -14,15 +14,15 @@ type LockerOptions struct {
 	prefix         string
 }
 
-func DefaultLockerOptions() *LockerOptions {
-	return &LockerOptions{
+func DefaultLockerOptions() LockerOptions {
+	return LockerOptions{
 		timeoutSeconds: 60,
 		prefix:         "/tusd",
 	}
 }
 
-func NewLockerOptions(timeout int, prefix string) *LockerOptions {
-	return &LockerOptions{
+func NewLockerOptions(timeout int, prefix string) LockerOptions {
+	return LockerOptions{
 		timeoutSeconds: timeout,
 		prefix:         prefix,
 	}

--- a/etcd3locker/locker_test.go
+++ b/etcd3locker/locker_test.go
@@ -1,0 +1,43 @@
+package etcd3locker
+
+import (
+	"github.com/coreos/etcd/clientv3"
+	etcd_harness "github.com/mwitkow/go-etcd-harness"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tus/tusd"
+)
+
+func TestEtcd3Locker(t *testing.T) {
+	a := assert.New(t)
+
+	harness, err := etcd_harness.New(os.Stderr)
+	if err != nil {
+		t.Fatalf("failed starting etcd harness: %v", err)
+	}
+	t.Logf("will use etcd harness endpoint: %v", harness.Endpoint)
+	defer func() {
+		harness.Stop()
+		t.Logf("cleaned up etcd harness")
+	}()
+
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{harness.Endpoint},
+		DialTimeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Unable to connect to etcd3: %v", err)
+	}
+	defer client.Close()
+
+	locker, err := New(client)
+	a.NoError(err)
+	a.NoError(locker.LockUpload("one"))
+	a.Equal(tusd.ErrFileLocked, locker.LockUpload("one"))
+	a.NoError(locker.UnlockUpload("one"))
+	a.Equal(ErrLockNotHeld, locker.UnlockUpload("one"))
+}

--- a/etcd3locker/locker_test.go
+++ b/etcd3locker/locker_test.go
@@ -43,6 +43,8 @@ func TestEtcd3Locker(t *testing.T) {
 	a.NoError(locker.LockUpload("one"))
 	a.Equal(tusd.ErrFileLocked, locker.LockUpload("one"))
 	time.Sleep(5 * time.Second)
+	// test that we can't take over the upload via a different etcd3 session
+	// while an upload is already taking place; testing etcd3 session KeepAlive
 	a.Equal(tusd.ErrFileLocked, locker.LockUpload("one"))
 	a.NoError(locker.UnlockUpload("one"))
 	a.Equal(ErrLockNotHeld, locker.UnlockUpload("one"))

--- a/etcd3locker/locker_test.go
+++ b/etcd3locker/locker_test.go
@@ -1,14 +1,13 @@
 package etcd3locker
 
 import (
-	"github.com/coreos/etcd/clientv3"
-	etcd_harness "github.com/mwitkow/go-etcd-harness"
+	"go.etcd.io/etcd/clientv3"
+	etcd_harness "github.com/chen-anders/go-etcd-harness"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
 	"github.com/tus/tusd"
 )
 

--- a/etcd3locker/locker_test.go
+++ b/etcd3locker/locker_test.go
@@ -1,8 +1,8 @@
 package etcd3locker
 
 import (
-	"go.etcd.io/etcd/clientv3"
 	etcd_harness "github.com/chen-anders/go-etcd-harness"
+	"go.etcd.io/etcd/clientv3"
 	"os"
 	"testing"
 	"time"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,6 +1,6 @@
 {
 	"comment": "",
-	"ignore": "test github.com/hashicorp/consul/ github.com/aws/aws-sdk-go/ github.com/prometheus/client_golang/prometheus/",
+	"ignore": "test github.com/hashicorp/consul/ github.com/aws/aws-sdk-go/ github.com/prometheus/client_golang/prometheus/ github.com/coreos/etcd github.com/mwitkow/go-etcd-harness",
 	"package": [
 		{
 			"path": "appengine",


### PR DESCRIPTION
Resolves: https://github.com/tus/tusd/issues/157

This is a first pass at an etcd3 locker that uses the built-in locks (from the `etcd/clientv3/concurrency` package). We create sessions with valid leases to lock an upload. Sessions are created with a renewing 60s lease (but kept alive with KeepAlive as long as the process is still alive). These sessions are reused to unlock uploads when the upload completes. Once an upload has been unlocked, we close the session. 

This code has been tested locally with an install of `etcd3` (3.1, 3.2, 3.3) with the use of the `go-etcd-harness`. 

We're also running this locker with some small scale traffic to our tusd server, in which we haven't seen issues so far. 

Example Usage (pseudocode):
```
import (
    "fmt"
    "time"
    "github.com/coreos/etcd/clientv3"
    "github.com/tus/tusd/etcd3locker"
    "github.com/tus/tusd"
)
...

etcdClient, err := clientv3.New(clientv3.Config{
	Endpoints:   ["127.0.0.1:2379"],
	DialTimeout: 2 * time.Second,
})
if err != nil {
	return nil, fmt.Errorf("Failed to create etcd client: %v", err.Error())
}
composer := tusd.NewStoreComposer()
locker, err := etcd3locker.New(etcdClient)
if err != nil {
	return nil, fmt.Errorf("Failed to create etcd locker: %v", err.Error())
}
locker.UseIn(composer)
```