### PR TITLE
Move to Standard library Context package

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Windows in various formats of the
 
 ### Compile from source
 
-The only requirement for building tusd is [Go](http://golang.org/doc/install) 1.5 or newer.
+The only requirement for building tusd is [Go](http://golang.org/doc/install) 1.7 or newer.
 If you meet this criteria, you can clone the git repository, install the remaining
 depedencies and build the binary:
 

--- a/gcsstore/gcsservice.go
+++ b/gcsstore/gcsservice.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/storage"
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 

--- a/gcsstore/gcsservice_test.go
+++ b/gcsstore/gcsservice_test.go
@@ -2,7 +2,7 @@ package gcsstore_test
 
 import (
 	"bytes"
-	"golang.org/x/net/context"
+	"context"
 	"testing"
 
 	"gopkg.in/h2non/gock.v1"

--- a/gcsstore/gcsstore.go
+++ b/gcsstore/gcsstore.go
@@ -14,7 +14,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/net/context"
+	"context"
 	"io"
 	"strconv"
 	"strings"

--- a/gcsstore/gcsstore_test.go
+++ b/gcsstore/gcsstore_test.go
@@ -2,9 +2,9 @@ package gcsstore_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/net/context"
 	"testing"
 
 	"cloud.google.com/go/storage"


### PR DESCRIPTION
Since december 2016, `context` is part of the  **Standard Go library.** 

It is the same code as `golang.org/x/net/context`.

The only thing that is missing is `ctxhttp` package but it is not used by tusd sources.

This modification implies to give up compatibility with go 1.5 and 1.6. But considering that right now GCSStore and Consul can't work on versions prior to 1.7, defining 1.7 as the minimal version could be a good choice no?

What do you guys think?

