### PR TITLE
Support prefix on S3 object names

### DIFF
--- a/cmd/tusd/cli/composer.go
+++ b/cmd/tusd/cli/composer.go
@@ -35,6 +35,7 @@ func CreateComposer() {
 		// Derive credentials from default credential chain (env, shared, ec2 instance role)
 		// as per https://github.com/aws/aws-sdk-go#configuring-credentials
 		store := s3store.New(Flags.S3Bucket, s3.New(session.Must(session.NewSession()), s3Config))
+		store.ObjectPrefix = Flags.S3ObjectPrefix
 		store.UseIn(Composer)
 
 		locker := memorylocker.New()

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -14,6 +14,7 @@ var Flags struct {
 	Basepath          string
 	Timeout           int64
 	S3Bucket          string
+	S3ObjectPrefix    string
 	S3Endpoint        string
 	GCSBucket     	  string
 	FileHooksDir      string
@@ -38,6 +39,7 @@ func ParseFlags() {
 	flag.StringVar(&Flags.Basepath, "base-path", "/files/", "Basepath of the HTTP server")
 	flag.Int64Var(&Flags.Timeout, "timeout", 30*1000, "Read timeout for connections in milliseconds.  A zero value means that reads will not timeout")
 	flag.StringVar(&Flags.S3Bucket, "s3-bucket", "", "Use AWS S3 with this bucket as storage backend (requires the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_REGION environment variables to be set)")
+	flag.StringVar(&Flags.S3ObjectPrefix, "s3-object-prefix", "", "Prefix for S3 object names")
 	flag.StringVar(&Flags.S3Endpoint, "s3-endpoint", "", "Endpoint to use S3 compatible implementations like minio (requires s3-bucket to be pass)")
 	flag.StringVar(&Flags.GCSBucket, "gcs-bucket", "", "Use Google Cloud Storage with this bucket as storage backend (requires the GCS_SERVICE_ACCOUNT_FILE environment variable to be set)")
 	flag.StringVar(&Flags.FileHooksDir, "hooks-dir", "", "Directory to search for available hooks scripts")

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -108,6 +108,10 @@ var nonASCIIRegexp = regexp.MustCompile(`([^\x00-\x7F])`)
 type S3Store struct {
 	// Bucket used to store the data in, e.g. "tusdstore.example.com"
 	Bucket string
+	// ObjectPrefix is prepended to the name of each S3 object that is created.
+	// It can be used to create a pseudo-directory structure in the bucket,
+	// e.g. "path/to/my/uploads".
+	ObjectPrefix string
 	// Service specifies an interface used to communicate with the S3 backend.
 	// Usually, this is an instance of github.com/aws/aws-sdk-go/service/s3.S3
 	// (http://docs.aws.amazon.com/sdk-for-go/api/service/s3/S3.html).


### PR DESCRIPTION
Currently, all objects in S3 are placed in the root of the bucket. This makes tusd adoption difficult for existing applications that use a different convention, such as using S3's support for prefixes to place objects in a pseudo-directory like `s3://my_bucket/media/incoming/<upload id>`. This PR introduces an `ObjectPrefix` field on `S3Store` to enable the use of prefixes.

Addresses one of the requests in #207.