### PR TITLE
S3Store: Add support for creation-defer-length extension

### DIFF
--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -145,6 +145,7 @@ type S3API interface {
 	PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error)
 	ListParts(input *s3.ListPartsInput) (*s3.ListPartsOutput, error)
 	UploadPart(input *s3.UploadPartInput) (*s3.UploadPartOutput, error)
+	HeadObject(input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error)
 	GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error)
 	CreateMultipartUpload(input *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error)
 	AbortMultipartUpload(input *s3.AbortMultipartUploadInput) (*s3.AbortMultipartUploadOutput, error)

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -364,7 +364,7 @@ func (store S3Store) GetInfo(id string) (info tusd.FileInfo, err error) {
 		Key:    store.keyWithPrefix(uploadId + ".part"),
 	})
 	if err != nil {
-		if !isAwsError(err, "NotFound") {
+		if !isAwsError(err, s3.ErrCodeNoSuchKey) {
 			return info, err
 		}
 

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -212,9 +212,18 @@ func (store S3Store) NewUpload(info tusd.FileInfo) (id string, err error) {
 	id = uploadId + "+" + *res.UploadId
 	info.ID = id
 
+	err = store.writeInfo(uploadId, info)
+	if err != nil {
+		return "", fmt.Errorf("s3store: unable to create info file:\n%s", err)
+	}
+
+	return id, nil
+}
+
+func (store S3Store) writeInfo(uploadId string, info tusd.FileInfo) error {
 	infoJson, err := json.Marshal(info)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	// Create object on S3 containing information about the file
@@ -224,11 +233,8 @@ func (store S3Store) NewUpload(info tusd.FileInfo) (id string, err error) {
 		Body:          bytes.NewReader(infoJson),
 		ContentLength: aws.Int64(int64(len(infoJson))),
 	})
-	if err != nil {
-		return "", fmt.Errorf("s3store: unable to create info file:\n%s", err)
-	}
 
-	return id, nil
+	return err
 }
 
 func (store S3Store) WriteChunk(id string, offset int64, src io.Reader) (int64, error) {

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -347,6 +347,21 @@ func (store S3Store) GetInfo(id string) (info tusd.FileInfo, err error) {
 		offset += *part.Size
 	}
 
+	headResult, err := store.Service.HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(store.Bucket),
+		Key:    aws.String(uploadId + ".part"),
+	})
+	if err != nil {
+		if !isAwsError(err, "NotFound") {
+			return info, err
+		}
+
+		err = nil
+	}
+	if headResult != nil && headResult.ContentLength != nil {
+		offset += *headResult.ContentLength
+	}
+
 	info.Offset = offset
 
 	return

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -364,7 +364,7 @@ func (store S3Store) GetInfo(id string) (info tusd.FileInfo, err error) {
 		Key:    store.keyWithPrefix(uploadId + ".part"),
 	})
 	if err != nil {
-		if !isAwsError(err, s3.ErrCodeNoSuchKey) {
+		if !isAwsError(err, s3.ErrCodeNoSuchKey) && !isAwsError(err, "AccessDenied") {
 			return info, err
 		}
 
@@ -632,7 +632,7 @@ func (store S3Store) getIncompletePartForUpload(uploadId string) (*s3.GetObjectO
 		Key:    store.keyWithPrefix(uploadId + ".part"),
 	})
 
-	if err != nil && isAwsError(err, s3.ErrCodeNoSuchKey) {
+	if err != nil && (isAwsError(err, s3.ErrCodeNoSuchKey) || isAwsError(err, "AccessDenied")) {
 		return nil, nil
 	}
 

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -174,6 +174,7 @@ func (store S3Store) UseIn(composer *tusd.StoreComposer) {
 	composer.UseFinisher(store)
 	composer.UseGetReader(store)
 	composer.UseConcater(store)
+	composer.UseLengthDeferrer(store)
 }
 
 func (store S3Store) NewUpload(info tusd.FileInfo) (id string, err error) {
@@ -563,6 +564,18 @@ func (store S3Store) ConcatUploads(dest string, partialUploads []string) error {
 	}
 
 	return store.FinishUpload(dest)
+}
+
+func (store S3Store) DeclareLength(id string, length int64) error {
+	uploadId, _ := splitIds(id)
+	info, err := store.GetInfo(id)
+	if err != nil {
+		return err
+	}
+	info.Size = length
+	info.SizeIsDeferred = false
+
+	return store.writeInfo(uploadId, info)
 }
 
 func (store S3Store) listAllParts(id string) (parts []*s3.Part, err error) {

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -431,13 +431,16 @@ func (store S3Store) Terminate(id string) error {
 	go func() {
 		defer wg.Done()
 
-		// Delete the info and content file
+		// Delete the info and content files
 		res, err := store.Service.DeleteObjects(&s3.DeleteObjectsInput{
 			Bucket: aws.String(store.Bucket),
 			Delete: &s3.Delete{
 				Objects: []*s3.ObjectIdentifier{
 					{
 						Key: store.keyWithPrefix(uploadId),
+					},
+					{
+						Key: store.keyWithPrefix(uploadId + ".part"),
 					},
 					{
 						Key: store.keyWithPrefix(uploadId + ".info"),

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -53,21 +53,10 @@
 //
 // In order to support tus' principle of resumable upload, S3's Multipart-Uploads
 // are internally used.
-// For each incoming PATCH request (a call to WriteChunk), a new part is uploaded
-// to S3. However, each part of a multipart upload, except the last one, must
-// be 5MB or bigger. This introduces a problem, since in tus' perspective
-// it's totally fine to upload just a few kilobytes in a single request.
-//
-// Therefore, a few special conditions have been implemented:
-//
-// Each PATCH request must contain a body of, at least, 5MB. If the size
-// is smaller than this limit, the entire request will be dropped and not
-// even passed to the storage server. If your server supports a different
-// limit, you can adjust this value using S3Store.MinPartSize.
 //
 // When receiving a PATCH request, its body will be temporarily stored on disk.
 // This requirement has been made to ensure the minimum size of a single part
-// and to allow the calculating of a checksum. Once the part has been uploaded
+// and to allow the AWS SDK to calculate a checksum. Once the part has been uploaded
 // to S3, the temporary file will be removed immediately. Therefore, please
 // ensure that the server running this storage backend has enough disk space
 // available to hold these caches.

--- a/s3store/s3store_mock_test.go
+++ b/s3store/s3store_mock_test.go
@@ -84,6 +84,17 @@ func (_mr *_MockS3APIRecorder) GetObject(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetObject", arg0)
 }
 
+func (_m *MockS3API) HeadObject(_param0 *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
+	ret := _m.ctrl.Call(_m, "HeadObject", _param0)
+	ret0, _ := ret[0].(*s3.HeadObjectOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockS3APIRecorder) HeadObject(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "HeadObject", arg0)
+}
+
 func (_m *MockS3API) ListParts(_param0 *s3.ListPartsInput) (*s3.ListPartsOutput, error) {
 	ret := _m.ctrl.Call(_m, "ListParts", _param0)
 	ret0, _ := ret[0].(*s3.ListPartsOutput)

--- a/s3store/s3store_test.go
+++ b/s3store/s3store_test.go
@@ -604,6 +604,9 @@ func TestTerminate(t *testing.T) {
 					Key: aws.String("uploadId"),
 				},
 				{
+					Key: aws.String("uploadId.part"),
+				},
+				{
 					Key: aws.String("uploadId.info"),
 				},
 			},
@@ -637,6 +640,9 @@ func TestTerminateWithErrors(t *testing.T) {
 			Objects: []*s3.ObjectIdentifier{
 				{
 					Key: aws.String("uploadId"),
+				},
+				{
+					Key: aws.String("uploadId.part"),
 				},
 				{
 					Key: aws.String("uploadId.info"),

--- a/s3store/s3store_test.go
+++ b/s3store/s3store_test.go
@@ -804,7 +804,7 @@ func TestWriteChunkAllowTooSmallLast(t *testing.T) {
 		s3obj.EXPECT().HeadObject(&s3.HeadObjectInput{
 			Bucket: aws.String("bucket"),
 			Key:    aws.String("uploadId.part"),
-		}).Return(&s3.HeadObjectOutput{}, awserr.New("NoSuchKey", "The specified key does not exist.", nil)),
+		}).Return(&s3.HeadObjectOutput{}, awserr.New("AccessDenied", "Access Denied.", nil)),
 		s3obj.EXPECT().ListParts(&s3.ListPartsInput{
 			Bucket:           aws.String("bucket"),
 			Key:              aws.String("uploadId"),

--- a/s3store/s3store_test.go
+++ b/s3store/s3store_test.go
@@ -205,7 +205,7 @@ func TestGetInfo(t *testing.T) {
 		s3obj.EXPECT().HeadObject(&s3.HeadObjectInput{
 			Bucket: aws.String("bucket"),
 			Key:    aws.String("uploadId.part"),
-		}).Return(&s3.HeadObjectOutput{}, awserr.New("NotFound", "Not found", nil)),
+		}).Return(&s3.HeadObjectOutput{}, awserr.New("NoSuchKey", "Not found", nil)),
 	)
 
 	info, err := store.GetInfo("uploadId+multipartId")
@@ -504,7 +504,7 @@ func TestWriteChunk(t *testing.T) {
 		s3obj.EXPECT().HeadObject(&s3.HeadObjectInput{
 			Bucket: aws.String("bucket"),
 			Key:    aws.String("uploadId.part"),
-		}).Return(&s3.HeadObjectOutput{}, awserr.New("NotFound", "Not found", nil)),
+		}).Return(&s3.HeadObjectOutput{}, awserr.New("NoSuchKey", "Not found", nil)),
 		s3obj.EXPECT().ListParts(&s3.ListPartsInput{
 			Bucket:           aws.String("bucket"),
 			Key:              aws.String("uploadId"),
@@ -590,7 +590,7 @@ func TestWriteChunkWriteIncompletePartBecauseTooSmall(t *testing.T) {
 		s3obj.EXPECT().HeadObject(&s3.HeadObjectInput{
 			Bucket: aws.String("bucket"),
 			Key:    aws.String("uploadId.part"),
-		}).Return(&s3.HeadObjectOutput{}, awserr.New("NotFound", "Not found", nil)),
+		}).Return(&s3.HeadObjectOutput{}, awserr.New("NoSuchKey", "The specified key does not exist", nil)),
 		s3obj.EXPECT().ListParts(&s3.ListPartsInput{
 			Bucket:           aws.String("bucket"),
 			Key:              aws.String("uploadId"),
@@ -804,7 +804,7 @@ func TestWriteChunkAllowTooSmallLast(t *testing.T) {
 		s3obj.EXPECT().HeadObject(&s3.HeadObjectInput{
 			Bucket: aws.String("bucket"),
 			Key:    aws.String("uploadId.part"),
-		}).Return(&s3.HeadObjectOutput{}, awserr.New("NotFound", "Not found", nil)),
+		}).Return(&s3.HeadObjectOutput{}, awserr.New("NoSuchKey", "The specified key does not exist.", nil)),
 		s3obj.EXPECT().ListParts(&s3.ListPartsInput{
 			Bucket:           aws.String("bucket"),
 			Key:              aws.String("uploadId"),

--- a/s3store/s3store_util_test.go
+++ b/s3store/s3store_util_test.go
@@ -55,3 +55,50 @@ func (m UploadPartInputMatcher) String() string {
 	m.expect.Body.Seek(0, 0)
 	return fmt.Sprintf("UploadPartInput(%d: %s)", *m.expect.PartNumber, body)
 }
+
+type PutObjectInputMatcher struct {
+	expect *s3.PutObjectInput
+}
+
+func NewPutObjectInputMatcher(expect *s3.PutObjectInput) gomock.Matcher {
+	return PutObjectInputMatcher{
+		expect: expect,
+	}
+}
+
+func (m PutObjectInputMatcher) Matches(x interface{}) bool {
+	input, ok := x.(*s3.PutObjectInput)
+	if !ok {
+		return false
+	}
+
+	inputBody := input.Body
+	expectBody := m.expect.Body
+
+	i, err := ioutil.ReadAll(inputBody)
+	if err != nil {
+		panic(err)
+	}
+	inputBody.Seek(0, 0)
+
+	e, err := ioutil.ReadAll(expectBody)
+	if err != nil {
+		panic(err)
+	}
+	m.expect.Body.Seek(0, 0)
+
+	if !reflect.DeepEqual(e, i) {
+		return false
+	}
+
+	input.Body = nil
+	m.expect.Body = nil
+
+	return reflect.DeepEqual(m.expect, input)
+}
+
+func (m PutObjectInputMatcher) String() string {
+	body, _ := ioutil.ReadAll(m.expect.Body)
+	m.expect.Body.Seek(0, 0)
+	return fmt.Sprintf(`PutObjectInput(Body: "%s")`, body)
+}


### PR DESCRIPTION
Currently, the S3 backend will drop non-final parts that are smaller than `MinPartSize` to comply with constraints in the AWS S3 service. This is inefficient, and it also prevents S3Store from supporting the `creation-defer-length` extension.

This PR implements an idea that was proposed in #182: when a part is smaller than `MinPartSize`, we send it to S3 temporarily as a normal (non-multipart upload) object. On the next `PATCH` request for the upload, the temporary part is retrieved from S3 and prepended to the request body. This process may be repeated until the part is large enough to be added to the multipart upload.