### PR TITLE
refactor(image): switch to a multistage build for the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
-FROM golang:1.7-alpine
+FROM golang:1.7-alpine AS builder
 
 # Copy in the git repo from the build context
 COPY . /go/src/github.com/tus/tusd/
 
 # Create app directory
+WORKDIR /go/src/github.com/tus/tusd
 
-RUN addgroup -g 1000 tusd \
-    && adduser -u 1000 -G tusd -s /bin/sh -D tusd \
-    && cd /go/src/github.com/tus/tusd \
-    && apk add --no-cache \
+RUN apk add --no-cache \
         git \
     && go get -d -v ./... \
     && version="$(git tag -l --points-at HEAD)" \
@@ -16,12 +14,21 @@ RUN addgroup -g 1000 tusd \
     && GOOS=linux GOARCH=amd64 go build \
         -ldflags="-X github.com/tus/tusd/cmd/tusd/cli.VersionName=${version} -X github.com/tus/tusd/cmd/tusd/cli.GitCommit=${commit} -X 'github.com/tus/tusd/cmd/tusd/cli.BuildDate=$(date --utc)'" \
         -o "/go/bin/tusd" ./cmd/tusd/main.go \
-    && mkdir -p /srv/tusd-hooks \
-    && mkdir -p /srv/tusd-data \
-    && chown tusd:tusd /srv/tusd-data \
     && rm -r /go/src/* \
     && apk del git
 
+# start a new stage that copies in the binary built in the previous stage
+FROM alpine:3.8
+
+COPY --from=builder /go/bin/tusd /usr/local/bin/tusd
+
+RUN addgroup -g 1000 tusd \
+    && adduser -u 1000 -G tusd -s /bin/sh -D tusd \
+    && mkdir -p /srv/tusd-hooks \
+    && mkdir -p /srv/tusd-data \
+    && chown tusd:tusd /srv/tusd-data
+
 WORKDIR /srv/tusd-data
 EXPOSE 1080
-ENTRYPOINT ["/go/bin/tusd","--hooks-dir","/srv/tusd-hooks"]
+ENTRYPOINT ["tusd"]
+CMD ["--hooks-dir","/srv/tusd-hooks"]


### PR DESCRIPTION
This makes it easier to reason about tusd's run environment. It also
significantly lowers the docker image size from 280MB for the current 0.11.0
image to only 26MB. Also not having the entire build environment in the
shipped images makes it quite attractive to use this image as a base
for other images. Those could contain some custom hooks for example.