### PR TITLE
Handle "NotFound" error code from HeadObject

### DIFF
--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -364,7 +364,7 @@ func (store S3Store) GetInfo(id string) (info tusd.FileInfo, err error) {
 		Key:    store.keyWithPrefix(uploadId + ".part"),
 	})
 	if err != nil {
-		if !isAwsError(err, s3.ErrCodeNoSuchKey) && !isAwsError(err, "AccessDenied") {
+		if !isAwsError(err, s3.ErrCodeNoSuchKey) && !isAwsError(err, "NotFound") && !isAwsError(err, "AccessDenied") {
 			return info, err
 		}
 

--- a/s3store/s3store_test.go
+++ b/s3store/s3store_test.go
@@ -381,9 +381,7 @@ func TestDeclareLength(t *testing.T) {
 		s3obj.EXPECT().HeadObject(&s3.HeadObjectInput{
 			Bucket: aws.String("bucket"),
 			Key:    aws.String("uploadId.part"),
-		}).Return(&s3.HeadObjectOutput{
-			ContentLength: aws.Int64(0),
-		}, nil),
+		}).Return(&s3.HeadObjectOutput{}, awserr.New("NotFound", "Not Found", nil)),
 		s3obj.EXPECT().PutObject(&s3.PutObjectInput{
 			Bucket:        aws.String("bucket"),
 			Key:           aws.String("uploadId.info"),


### PR DESCRIPTION
A case that isn't covered by #219 is when the `HeadObject` call to the S3 endpoint returns `NotFound` instead of `NoSuchKey` or `AccessDenied`. Depending on the permissions granted to the request, any of these errors may be returned.

This also accommodates third party implementations of the S3 interface, such as Minio, whose behavior may differ slightly from S3's.

Resolves #226.