### PR TITLE
Install new Docker version on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ go:
 sudo: required
 dist: trusty
 group: deprecated-2017Q4
+addons:
+  apt:
+    packages:
+      - docker-ce
 cache:
   apt: true
   directories:


### PR DESCRIPTION
The new Docker instructions require a newer version than is installed on Travis CI by default.