### PR TITLE
S3Store: IAM fixes for incomplete parts

### DIFF
--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -137,6 +137,7 @@ type S3API interface {
 	GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error)
 	CreateMultipartUpload(input *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error)
 	AbortMultipartUpload(input *s3.AbortMultipartUploadInput) (*s3.AbortMultipartUploadOutput, error)
+	DeleteObject(input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error)
 	DeleteObjects(input *s3.DeleteObjectsInput) (*s3.DeleteObjectsOutput, error)
 	CompleteMultipartUpload(input *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error)
 	UploadPartCopy(input *s3.UploadPartCopyInput) (*s3.UploadPartCopyOutput, error)

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -134,7 +134,6 @@ type S3API interface {
 	PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error)
 	ListParts(input *s3.ListPartsInput) (*s3.ListPartsOutput, error)
 	UploadPart(input *s3.UploadPartInput) (*s3.UploadPartOutput, error)
-	HeadObject(input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error)
 	GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error)
 	CreateMultipartUpload(input *s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error)
 	AbortMultipartUpload(input *s3.AbortMultipartUploadInput) (*s3.AbortMultipartUploadOutput, error)

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -653,15 +653,9 @@ func (store S3Store) putIncompletePartForUpload(uploadId string, r io.ReadSeeker
 }
 
 func (store S3Store) deleteIncompletePartForUpload(uploadId string) error {
-	_, err := store.Service.DeleteObjects(&s3.DeleteObjectsInput{
+	_, err := store.Service.DeleteObject(&s3.DeleteObjectInput{
 		Bucket: aws.String(store.Bucket),
-		Delete: &s3.Delete{
-			Objects: []*s3.ObjectIdentifier{
-				{
-					Key: store.keyWithPrefix(uploadId + ".part"),
-				},
-			},
-		},
+		Key:    store.keyWithPrefix(uploadId + ".part"),
 	})
 	return err
 }

--- a/s3store/s3store_mock_test.go
+++ b/s3store/s3store_mock_test.go
@@ -62,6 +62,17 @@ func (_mr *_MockS3APIRecorder) CreateMultipartUpload(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateMultipartUpload", arg0)
 }
 
+func (_m *MockS3API) DeleteObject(_param0 *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+	ret := _m.ctrl.Call(_m, "DeleteObject", _param0)
+	ret0, _ := ret[0].(*s3.DeleteObjectOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockS3APIRecorder) DeleteObject(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteObject", arg0)
+}
+
 func (_m *MockS3API) DeleteObjects(_param0 *s3.DeleteObjectsInput) (*s3.DeleteObjectsOutput, error) {
 	ret := _m.ctrl.Call(_m, "DeleteObjects", _param0)
 	ret0, _ := ret[0].(*s3.DeleteObjectsOutput)

--- a/s3store/s3store_mock_test.go
+++ b/s3store/s3store_mock_test.go
@@ -84,17 +84,6 @@ func (_mr *_MockS3APIRecorder) GetObject(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetObject", arg0)
 }
 
-func (_m *MockS3API) HeadObject(_param0 *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
-	ret := _m.ctrl.Call(_m, "HeadObject", _param0)
-	ret0, _ := ret[0].(*s3.HeadObjectOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockS3APIRecorder) HeadObject(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "HeadObject", arg0)
-}
-
 func (_m *MockS3API) ListParts(_param0 *s3.ListPartsInput) (*s3.ListPartsOutput, error) {
 	ret := _m.ctrl.Call(_m, "ListParts", _param0)
 	ret0, _ := ret[0].(*s3.ListPartsOutput)

--- a/s3store/s3store_test.go
+++ b/s3store/s3store_test.go
@@ -594,10 +594,10 @@ func TestWriteChunkWithUnexpectedEOF(t *testing.T) {
 				},
 			},
 		}, nil),
-		s3obj.EXPECT().HeadObject(&s3.HeadObjectInput{
+		s3obj.EXPECT().GetObject(&s3.GetObjectInput{
 			Bucket: aws.String("bucket"),
 			Key:    aws.String("uploadId.part"),
-		}).Return(&s3.HeadObjectOutput{}, awserr.New("NoSuchKey", "Not found", nil)),
+		}).Return(&s3.GetObjectOutput{}, awserr.New("NoSuchKey", "Not found", nil)),
 		s3obj.EXPECT().ListParts(&s3.ListPartsInput{
 			Bucket:           aws.String("bucket"),
 			Key:              aws.String("uploadId"),
@@ -746,16 +746,10 @@ func TestWriteChunkPrependsIncompletePart(t *testing.T) {
 			ContentLength: aws.Int64(3),
 			Body:          ioutil.NopCloser(bytes.NewReader([]byte("123"))),
 		}, nil),
-		s3obj.EXPECT().DeleteObjects(&s3.DeleteObjectsInput{
+		s3obj.EXPECT().DeleteObject(&s3.DeleteObjectInput{
 			Bucket: aws.String(store.Bucket),
-			Delete: &s3.Delete{
-				Objects: []*s3.ObjectIdentifier{
-					{
-						Key: aws.String("uploadId.part"),
-					},
-				},
-			},
-		}).Return(nil, nil),
+			Key:    aws.String("uploadId.part"),
+		}).Return(&s3.DeleteObjectOutput{}, nil),
 		s3obj.EXPECT().UploadPart(NewUploadPartInputMatcher(&s3.UploadPartInput{
 			Bucket:     aws.String("bucket"),
 			Key:        aws.String("uploadId"),
@@ -822,16 +816,10 @@ func TestWriteChunkPrependsIncompletePartAndWritesANewIncompletePart(t *testing.
 			Body:          ioutil.NopCloser(bytes.NewReader([]byte("123"))),
 			ContentLength: aws.Int64(3),
 		}, nil),
-		s3obj.EXPECT().DeleteObjects(&s3.DeleteObjectsInput{
+		s3obj.EXPECT().DeleteObject(&s3.DeleteObjectInput{
 			Bucket: aws.String(store.Bucket),
-			Delete: &s3.Delete{
-				Objects: []*s3.ObjectIdentifier{
-					{
-						Key: aws.String("uploadId.part"),
-					},
-				},
-			},
-		}).Return(nil, nil),
+			Key:    aws.String("uploadId.part"),
+		}).Return(&s3.DeleteObjectOutput{}, nil),
 		s3obj.EXPECT().UploadPart(NewUploadPartInputMatcher(&s3.UploadPartInput{
 			Bucket:     aws.String("bucket"),
 			Key:        aws.String("uploadId"),


### PR DESCRIPTION
This is a followup from #219 and addresses two issues related to IAM permissions. 

First, the use of `HeadObject` as an optimization requires the `s3:ListBucket` permission to be granted, and using both `HeadObject` and `GetObject` to reference .part files was difficult to reason about. This is resolved by using `GetObject` only. ~Second, buckets that are configured with object versioning would have needed the `s3:DeleteObject` and `s3:DeleteObjectVersion` permissions to be granted, which is not ideal and represents a breaking change. By overwriting the existing .part object (if any) with an empty one, we can avoid the complexity associated with deleting objects.~ (See comments below.)

See #226 for more discussion.