### PR TITLE
s3store: Changed AccessDenied error to Forbidden

### DIFF
--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -374,7 +374,7 @@ func (store S3Store) GetInfo(id string) (info tusd.FileInfo, err error) {
 		Key:    store.keyWithPrefix(uploadId + ".part"),
 	})
 	if err != nil {
-		if !isAwsError(err, s3.ErrCodeNoSuchKey) && !isAwsError(err, "NotFound") && !isAwsError(err, "Forbidden") {
+		if !isAwsError(err, s3.ErrCodeNoSuchKey) && !isAwsError(err, "NotFound") && !isAwsError(err, "AccessDenied") && !isAwsError(err, "Forbidden") {
 			return info, err
 		}
 

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -374,7 +374,7 @@ func (store S3Store) GetInfo(id string) (info tusd.FileInfo, err error) {
 		Key:    store.keyWithPrefix(uploadId + ".part"),
 	})
 	if err != nil {
-		if !isAwsError(err, s3.ErrCodeNoSuchKey) && !isAwsError(err, "NotFound") && !isAwsError(err, "AccessDenied") {
+		if !isAwsError(err, s3.ErrCodeNoSuchKey) && !isAwsError(err, "NotFound") && !isAwsError(err, "Forbidden") {
 			return info, err
 		}
 


### PR DESCRIPTION
There's a bug in s3store. To reproduce,

1. Setup tusd with S3 and only recommended IAM permissions.
2. `curl -H 'Tus-Resumable: 1.0.0' -H 'Upload-Length: 100' -X POST http://tus/files/` i.e. create an upload but don't upload anything
3. `tus-resume file http://tus/id+multipartid`
4. tus-resume will get 403 error from tusd

The root cause is:

1. As we never uploaded anything, the `id.part` file is not present
2. Per the recommended IAM permissions, ListBucket is not granted.
3. GetInfo will try to HEAD the `id.part` file, resulting in 403 error and not 404 due to 2)
4. There's a check in the line I've edited to ignore 403 error, but it's not correct. This PR corrects that.