### PR TITLE
Docs: consullocker/etcd3locker - correct UnlockUpload method docs

### DIFF
--- a/consullocker/consullocker.go
+++ b/consullocker/consullocker.go
@@ -104,7 +104,7 @@ func (locker *ConsulLocker) LockUpload(id string) error {
 	return nil
 }
 
-// UnlockUpload releases a lock. If no such lock exists, no error will be returned.
+// UnlockUpload releases a lock.
 func (locker *ConsulLocker) UnlockUpload(id string) error {
 	locker.mutex.Lock()
 	defer locker.mutex.Unlock()

--- a/etcd3locker/locker.go
+++ b/etcd3locker/locker.go
@@ -115,7 +115,7 @@ func (locker *Etcd3Locker) LockUpload(id string) error {
 	return nil
 }
 
-// UnlockUpload releases a lock. If no such lock exists, no error will be returned.
+// UnlockUpload releases a lock.
 func (locker *Etcd3Locker) UnlockUpload(id string) error {
 	locker.mutex.Lock()
 	defer locker.mutex.Unlock()


### PR DESCRIPTION
The following statement in the docs is not accurate for consullocker and etcd3locker. 

> If no such lock exists, no error will be returned. 

This PR removes that statement for both locker implementations. 
