### PR TITLE
Post receive disable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tusd/data
+/tusd
 cover.out
 data/
 node_modules/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img alt="Tus logo" src="https://github.com/tus/tus.io/blob/master/assets/img/tus1.png?raw=true" width="30%" align="right" />
 
-> **tus** is a protocol based on HTTP for *resumable file uploads*. Resumable
+> **tus** is a protocol based on HTTP for _resumable file uploads_. Resumable
 > means that an upload can be interrupted at any moment and can be resumed without
 > re-uploading the previous data again. An interruption may happen willingly, if
 > the user wants to pause, or by accident in case of an network issue or server
@@ -124,6 +124,8 @@ Usage of tusd:
     	Path under which the metrics endpoint will be accessible (default "/metrics")
   -port string
     	Port to bind HTTP server to (default "1080")
+	-post-receive-enabled bool
+		Set to false to disable the post-receive hook when hooks are enabled. Useful to reduce server load for your webhook endpoint when this hook is not required. (default true)
   -s3-bucket string
     	Use AWS S3 with this bucket as storage backend (requires the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_REGION environment variables to be set)
   -s3-endpoint string
@@ -220,13 +222,13 @@ required methods.
 This repository does not only contain the HTTP server's code but also other
 useful tools:
 
-* [**s3store**](https://godoc.org/github.com/tus/tusd/s3store): A storage backend using AWS S3
-* [**filestore**](https://godoc.org/github.com/tus/tusd/filestore): A storage backend using the local file system
-* [**gcsstore**](https://godoc.org/github.com/tus/tusd/gcsstore): A storage backend using Google cloud storage
-* [**memorylocker**](https://godoc.org/github.com/tus/tusd/memorylocker): An in-memory locker for handling concurrent uploads
-* [**consullocker**](https://godoc.org/github.com/tus/tusd/consullocker): A locker using the distributed Consul service
-* [**etcd3locker**](https://godoc.org/github.com/tus/tusd/etcd3locker): A locker using the distributed KV etcd3 store
-* [**limitedstore**](https://godoc.org/github.com/tus/tusd/limitedstore): A storage wrapper limiting the total used space for uploads
+- [**s3store**](https://godoc.org/github.com/tus/tusd/s3store): A storage backend using AWS S3
+- [**filestore**](https://godoc.org/github.com/tus/tusd/filestore): A storage backend using the local file system
+- [**gcsstore**](https://godoc.org/github.com/tus/tusd/gcsstore): A storage backend using Google cloud storage
+- [**memorylocker**](https://godoc.org/github.com/tus/tusd/memorylocker): An in-memory locker for handling concurrent uploads
+- [**consullocker**](https://godoc.org/github.com/tus/tusd/consullocker): A locker using the distributed Consul service
+- [**etcd3locker**](https://godoc.org/github.com/tus/tusd/etcd3locker): A locker using the distributed KV etcd3 store
+- [**limitedstore**](https://godoc.org/github.com/tus/tusd/limitedstore): A storage wrapper limiting the total used space for uploads
 
 ## Running the testsuite
 
@@ -241,17 +243,17 @@ go test -v ./...
 
 ### How can I access tusd using HTTPS?
 
-The tusd binary, once executed, listens on the provided port for only non-encrypted HTTP requests and *does not accept* HTTPS connections. This decision has been made to limit the functionality inside this repository which has to be developed, tested and maintained. If you want to send requests to tusd in a secure fashion - what we absolutely encourage, we recommend you to utilize a reverse proxy in front of tusd which accepts incoming HTTPS connections and forwards them to tusd using plain HTTP. More information about this topic, including sample configurations for Nginx and Apache, can be found in [issue #86](https://github.com/tus/tusd/issues/86#issuecomment-269569077) and in the [Apache example configuration](/docs/apache2.conf).
+The tusd binary, once executed, listens on the provided port for only non-encrypted HTTP requests and _does not accept_ HTTPS connections. This decision has been made to limit the functionality inside this repository which has to be developed, tested and maintained. If you want to send requests to tusd in a secure fashion - what we absolutely encourage, we recommend you to utilize a reverse proxy in front of tusd which accepts incoming HTTPS connections and forwards them to tusd using plain HTTP. More information about this topic, including sample configurations for Nginx and Apache, can be found in [issue #86](https://github.com/tus/tusd/issues/86#issuecomment-269569077) and in the [Apache example configuration](/docs/apache2.conf).
 
 ### Can I run tusd behind a reverse proxy?
 
 Yes, it is absolutely possible to do so. Firstly, you should execute the tusd binary using the `-behind-proxy` flag indicating it to pay attention to special headers which are only relevant when used in conjunction with a proxy. Furthermore, there are additional details which should be kept in mind, depending on the used software:
 
-- *Disable request buffering.* Nginx, for example, reads the entire incoming HTTP request, including its body, before sending it to the backend, by default. This behavior defeats the purpose of resumability where an upload is processed while it's being transfered. Therefore, such as feature should be disabled.
+- _Disable request buffering._ Nginx, for example, reads the entire incoming HTTP request, including its body, before sending it to the backend, by default. This behavior defeats the purpose of resumability where an upload is processed while it's being transfered. Therefore, such as feature should be disabled.
 
-- *Adjust maximum request size.* Some proxies have default values for how big a request may be in order to protect your services. Be sure to check these settings to match the requirements of your application.
+- _Adjust maximum request size._ Some proxies have default values for how big a request may be in order to protect your services. Be sure to check these settings to match the requirements of your application.
 
-- *Forward hostname and scheme.* If the proxy rewrites the request URL, the tusd server does not know the original URL which was used to reach the proxy. This behavior can lead to situations, where tusd returns a redirect to a URL which can not be reached by the client. To avoid this confusion, you can explicitly tell tusd which hostname and scheme to use by supplying the `X-Forwarded-Host` and `X-Forwarded-Proto` headers.
+- _Forward hostname and scheme._ If the proxy rewrites the request URL, the tusd server does not know the original URL which was used to reach the proxy. This behavior can lead to situations, where tusd returns a redirect to a URL which can not be reached by the client. To avoid this confusion, you can explicitly tell tusd which hostname and scheme to use by supplying the `X-Forwarded-Host` and `X-Forwarded-Proto` headers.
 
 Explicit examples for the above points can be found in the [Nginx configuration](/docs/nginx.conf) which is used to power the [master.tus.io](https://master.tus.io) instace.
 

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -6,28 +6,28 @@ import (
 )
 
 var Flags struct {
-	HttpHost          string
-	HttpPort          string
-	MaxSize           int64
-	UploadDir         string
-	StoreSize         int64
-	Basepath          string
-	Timeout           int64
-	S3Bucket          string
-	S3ObjectPrefix    string
-	S3Endpoint        string
-	GCSBucket     	  string
-	FileHooksDir      string
-	HttpHooksEndpoint string
-	HttpHooksRetry    int
-	HttpHooksBackoff  int
-	ShowVersion       bool
-	ExposeMetrics     bool
-	MetricsPath       string
-	BehindProxy       bool
-
-	FileHooksInstalled bool
-	HttpHooksInstalled bool
+	HttpHost                string
+	HttpPort                string
+	MaxSize                 int64
+	UploadDir               string
+	StoreSize               int64
+	Basepath                string
+	Timeout                 int64
+	S3Bucket                string
+	S3ObjectPrefix          string
+	S3Endpoint              string
+	GCSBucket               string
+	FileHooksDir            string
+	HttpHooksEndpoint       string
+	HttpHooksRetry          int
+	HttpHooksBackoff        int
+	HooksPostReceiveEnabled bool
+	ShowVersion             bool
+	ExposeMetrics           bool
+	MetricsPath             string
+	BehindProxy             bool
+	FileHooksInstalled      bool
+	HttpHooksInstalled      bool
 }
 
 func ParseFlags() {
@@ -46,6 +46,7 @@ func ParseFlags() {
 	flag.StringVar(&Flags.HttpHooksEndpoint, "hooks-http", "", "An HTTP endpoint to which hook events will be sent to")
 	flag.IntVar(&Flags.HttpHooksRetry, "hooks-http-retry", 3, "Number of times to retry on a 500 or network timeout")
 	flag.IntVar(&Flags.HttpHooksBackoff, "hooks-http-backoff", 1, "Number of seconds to wait before retrying each retry")
+	flag.BoolVar(&Flags.HooksPostReceiveEnabled, "post-receive-enabled", true, "Set to false to disable the post-receive hook when hooks are enabled. Useful to reduce server load for your webhook endpoint when this hook is not required.")
 	flag.BoolVar(&Flags.ShowVersion, "version", false, "Print tusd version information")
 	flag.BoolVar(&Flags.ExposeMetrics, "expose-metrics", true, "Expose metrics about tusd usage")
 	flag.StringVar(&Flags.MetricsPath, "metrics-path", "/metrics", "Path under which the metrics endpoint will be accessible")

--- a/cmd/tusd/cli/hooks.go
+++ b/cmd/tusd/cli/hooks.go
@@ -81,6 +81,10 @@ func invokeHookSync(typ HookType, info tusd.FileInfo, captureOutput bool) ([]byt
 		logEv(stdout, "UploadFinished", "id", info.ID, "size", strconv.FormatInt(info.Size, 10))
 	case HookPostTerminate:
 		logEv(stdout, "UploadTerminated", "id", info.ID)
+	case HookPostReceive:
+		if !Flags.HooksPostReceiveEnabled {
+			return nil, nil
+		}
 	}
 
 	if !Flags.FileHooksInstalled && !Flags.HttpHooksInstalled {

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -9,9 +9,9 @@ When a specific action happens during an upload (pre-create, post-receive, post-
 
 ## Blocking and Non-Blocking Hooks
 
-If not otherwise noted, all hooks are invoked in a *non-blocking* way, meaning that tusd will not wait until the hook process has finished and exited. Therefore, the hook process is not able to influence how tusd may continue handling the current request, regardless of which exit code it may set. Furthermore, the hook process' stdout and stderr will be piped to tusd's stdout and stderr correspondingly, allowing one to use these channels for additional logging.
+If not otherwise noted, all hooks are invoked in a _non-blocking_ way, meaning that tusd will not wait until the hook process has finished and exited. Therefore, the hook process is not able to influence how tusd may continue handling the current request, regardless of which exit code it may set. Furthermore, the hook process' stdout and stderr will be piped to tusd's stdout and stderr correspondingly, allowing one to use these channels for additional logging.
 
-On the other hand, there are a few *blocking* hooks, such as caused by the `pre-create` event. Because their exit code will dictate whether tusd will accept the current incoming request, tusd will wait until the hook process has exited. Therefore, in order to keep the response times low, one should avoid to make time-consuming operations inside the processes for blocking hooks. An exit code of `0` indicates that tusd should continue handling the request as normal. On the other hand, a non-zero exit code tells tusd to reject the request with a `500 Internal Server Error` response containing the process' output from stderr. For the sake of logging, the process' output from stdout will always be piped to tusd's stdout.
+On the other hand, there are a few _blocking_ hooks, such as caused by the `pre-create` event. Because their exit code will dictate whether tusd will accept the current incoming request, tusd will wait until the hook process has exited. Therefore, in order to keep the response times low, one should avoid to make time-consuming operations inside the processes for blocking hooks. An exit code of `0` indicates that tusd should continue handling the request as normal. On the other hand, a non-zero exit code tells tusd to reject the request with a `500 Internal Server Error` response containing the process' output from stderr. For the sake of logging, the process' output from stdout will always be piped to tusd's stdout.
 
 ## List of Available Hooks
 
@@ -21,7 +21,7 @@ This event will be triggered before an upload is created, allowing you to run ce
 
 ### post-create
 
-This event will be triggered after an upload is created, allowing you to run certain routines. For example, notifying other parts of your system that a new upload has to be handled. At this point the upload may have received some data already since the invocation of these hooks may be delayed by a short duration. 
+This event will be triggered after an upload is created, allowing you to run certain routines. For example, notifying other parts of your system that a new upload has to be handled. At this point the upload may have received some data already since the invocation of these hooks may be delayed by a short duration.
 
 ### post-finish
 
@@ -33,11 +33,12 @@ This event will be triggered after an upload has been terminated, meaning that t
 
 ### post-receive
 
-This event will be triggered for every running upload to indicate its current progress. It will occur for each open PATCH request, every second. The offset property will be set to the number of bytes which have been transfered to the server, at the time in total. Please be aware that this number may be higher than the number of bytes which have been stored by the data store!
-
+This event will be triggered for every running upload to indicate its current progress. It will occur for each open PATCH request, every second. The offset property will be set to the number of bytes which have been transfered to the server, at the time in total. Please be aware that this number may be higher than the number of bytes which have been stored by the data store! This hook can be disabled with `-post-receive-enabled=false`.
 
 ## File Hooks
+
 ### The Hook Directory
+
 By default, the file hook system is disabled. To enable it, pass the `--hooks-dir` option to the tusd binary. The flag's value will be a path, the **hook directory**, relative to the current working directory, pointing to the folder containing the executable **hook files**:
 
 ```bash
@@ -48,13 +49,14 @@ $ tusd --hooks-dir ./path/to/hooks/
 ...
 ```
 
-If an event occurs, the tusd binary will look for a file, named exactly as the event, which will then be executed, as long as the object exists. In the example above, the binary `./path/to/hooks/pre-create` will be invoked, before an upload is created, which can be used to e.g. validate certain metadata. Please note, that the hook file *must not* have an extension, such as `.sh` or `.py`, or else tusd will not recognize and ignore it. A detailed list of all events can be found at the end of this document.
+If an event occurs, the tusd binary will look for a file, named exactly as the event, which will then be executed, as long as the object exists. In the example above, the binary `./path/to/hooks/pre-create` will be invoked, before an upload is created, which can be used to e.g. validate certain metadata. Please note, that the hook file _must not_ have an extension, such as `.sh` or `.py`, or else tusd will not recognize and ignore it. A detailed list of all events can be found at the end of this document.
 
 ### The Hook's Environment
 
 The process of the hook files are provided with information about the event and the upload using to two methods:
-* The `TUS_ID` and `TUS_SIZE` environment variables will contain the upload ID and its size in bytes, which triggered the event. Please be aware, that in the `pre-create` hook the upload ID will be an empty string as the entity has not been created and therefore this piece of information is not yet available.
-* On `stdin` a JSON-encoded object can be read which contains more details about the corresponding upload in following format:
+
+- The `TUS_ID` and `TUS_SIZE` environment variables will contain the upload ID and its size in bytes, which triggered the event. Please be aware, that in the `pre-create` hook the upload ID will be an empty string as the entity has not been created and therefore this piece of information is not yet available.
+- On `stdin` a JSON-encoded object can be read which contains more details about the corresponding upload in following format:
 
 ```js
 {
@@ -82,8 +84,7 @@ The process of the hook files are provided with information about the event and 
 }
 ```
 
-Be aware that this environment does *not* contain direct data from any HTTP request, in particular not any header values or cookies. If you would like to pass information from the client to the hook, such as authentication details, you may wish to use the [metadata system](http://tus.io/protocols/resumable-upload.html#upload-metadata).
-
+Be aware that this environment does _not_ contain direct data from any HTTP request, in particular not any header values or cookies. If you would like to pass information from the client to the hook, such as authentication details, you may wish to use the [metadata system](http://tus.io/protocols/resumable-upload.html#upload-metadata).
 
 ## HTTP Hooks
 
@@ -100,7 +101,6 @@ $ tusd --hooks-http http://localhost:8081/write
 Note that the URL must include the `http://` prefix!
 
 In case of a blocking hook, HTTP Status Code 400 or greater tells tusd to reject the request (in the same way as non-zero exit code for File Hooks). See also [issue #170](https://github.com/tus/tusd/issues/170) regarding further improvements.
-
 
 ### Usage
 


### PR DESCRIPTION
This PR adds the option to disable to the post-receive hook via a new command line flag. It remains enabled by default.

Related: #239