### PR TITLE
Enable the sample hook files to execute without error to fix #203

### DIFF
--- a/.hooks/post-create
+++ b/.hooks/post-create
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 id="$TUS_ID"
 offset="$TUS_OFFSET"

--- a/.hooks/post-finish
+++ b/.hooks/post-finish
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Upload $TUS_ID ($TUS_SIZE bytes) finished"
 cat /dev/stdin | jq .

--- a/.hooks/post-receive
+++ b/.hooks/post-receive
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 id="$TUS_ID"
 offset="$TUS_OFFSET"

--- a/.hooks/post-terminate
+++ b/.hooks/post-terminate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Upload $TUS_ID terminated"
 cat /dev/stdin | jq .

--- a/.hooks/pre-create
+++ b/.hooks/pre-create
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 filename=$(cat /dev/stdin | jq .MetaData.filename)
 if [ -z "$filename" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM alpine:3.8
 
 COPY --from=builder /go/bin/tusd /usr/local/bin/tusd
 
-RUN apk add --no-cache ca-certificates \
+RUN apk add --no-cache ca-certificates jq \
     && addgroup -g 1000 tusd \
     && adduser -u 1000 -G tusd -s /bin/sh -D tusd \
     && mkdir -p /srv/tusd-hooks \


### PR DESCRIPTION
Hi,

this PR is to fix #203. It does:

Update Dockerfile to install the small jq package to parse the JSON data.
Update all the sample hook files to replace "bash" with "sh"
as bash is not installed by default in Alpine linux
and we don't want to install it as it's not a lightweight package.

The container size before this PR: 26.7MB
The container sizse after this PR:  27.7MB

Kind regards
Rija