### PR TITLE
Create CLI option to bind to UNIX socket

### DIFF
--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -8,6 +8,7 @@ import (
 var Flags struct {
 	HttpHost          string
 	HttpPort          string
+	HttpSock          string
 	MaxSize           int64
 	UploadDir         string
 	StoreSize         int64
@@ -16,7 +17,7 @@ var Flags struct {
 	S3Bucket          string
 	S3ObjectPrefix    string
 	S3Endpoint        string
-	GCSBucket     	  string
+	GCSBucket         string
 	FileHooksDir      string
 	HttpHooksEndpoint string
 	HttpHooksRetry    int
@@ -33,6 +34,7 @@ var Flags struct {
 func ParseFlags() {
 	flag.StringVar(&Flags.HttpHost, "host", "0.0.0.0", "Host to bind HTTP server to")
 	flag.StringVar(&Flags.HttpPort, "port", "1080", "Port to bind HTTP server to")
+	flag.StringVar(&Flags.HttpSock, "unix-sock", "", "If set, will listen to a UNIX socket at this location instead of a TCP socket")
 	flag.Int64Var(&Flags.MaxSize, "max-size", 0, "Maximum size of a single upload in bytes")
 	flag.StringVar(&Flags.UploadDir, "dir", "./data", "Directory to store uploads in")
 	flag.Int64Var(&Flags.StoreSize, "store-size", 0, "Size of space allowed for storage")

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -1,12 +1,19 @@
 package cli
 
 import (
+	"net"
 	"net/http"
 	"time"
 
 	"github.com/tus/tusd"
 )
 
+// Setups the different components, starts a Listener and give it to
+// http.Serve().
+//
+// By default it will bind to the specified host/port, unless a UNIX socket is
+// specified, in which case a different socket creation and binding mechanism
+// is put in place.
 func Serve() {
 	SetupPreHooks(Composer)
 
@@ -24,10 +31,17 @@ func Serve() {
 		stderr.Fatalf("Unable to create handler: %s", err)
 	}
 
-	address := Flags.HttpHost + ":" + Flags.HttpPort
 	basepath := Flags.Basepath
+	address := ""
 
-	stdout.Printf("Using %s as address to listen.\n", address)
+	if Flags.HttpSock != "" {
+		address = Flags.HttpSock
+		stdout.Printf("Using %s as socket to listen.\n", address)
+	} else {
+		address = Flags.HttpHost + ":" + Flags.HttpPort
+		stdout.Printf("Using %s as address to listen.\n", address)
+	}
+
 	stdout.Printf("Using %s as the base path.\n", basepath)
 
 	SetupPostHooks(handler)
@@ -47,8 +61,15 @@ func Serve() {
 
 	http.Handle(basepath, http.StripPrefix(basepath, handler))
 
+	var listener net.Listener
 	timeoutDuration := time.Duration(Flags.Timeout) * time.Millisecond
-	listener, err := NewListener(address, timeoutDuration, timeoutDuration)
+
+	if Flags.HttpSock != "" {
+		listener, err = NewUnixListener(address, timeoutDuration, timeoutDuration)
+	} else {
+		listener, err = NewListener(address, timeoutDuration, timeoutDuration)
+	}
+
 	if err != nil {
 		stderr.Fatalf("Unable to create listener: %s", err)
 	}


### PR DESCRIPTION
As suggested in tus/tusd#264, this PR brings the ability for `tusd` to bind to a UNIX socket.

The implementation adds a `-unix-sock` CLI option which if set to a non-empty value will bind `tusd` to the provided path and discard the TCP host and port.

I'm unsure about the standards of the project, so please me how I can improve this.