### PR TITLE
support object prefix on GCS object names

### DIFF
--- a/cmd/tusd/cli/composer.go
+++ b/cmd/tusd/cli/composer.go
@@ -55,7 +55,8 @@ func CreateComposer() {
 
 		stdout.Printf("Using 'gcs://%s' as GCS bucket for storage.\n", Flags.GCSBucket)
 
-		store := gcsstore.New(Flags.GCSBucket, Flags.GCSObjectPrefix, service)
+		store := gcsstore.New(Flags.GCSBucket, service)
+		store.ObjectPrefix = Flags.GCSObjectPrefix
 		store.UseIn(Composer)
 
 		locker := memorylocker.New()

--- a/cmd/tusd/cli/composer.go
+++ b/cmd/tusd/cli/composer.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/tus/tusd"
 	"github.com/tus/tusd/filestore"
+	"github.com/tus/tusd/gcsstore"
 	"github.com/tus/tusd/limitedstore"
 	"github.com/tus/tusd/memorylocker"
 	"github.com/tus/tusd/s3store"
-	"github.com/tus/tusd/gcsstore"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -55,7 +55,7 @@ func CreateComposer() {
 
 		stdout.Printf("Using 'gcs://%s' as GCS bucket for storage.\n", Flags.GCSBucket)
 
-		store := gcsstore.New(Flags.GCSBucket, service)
+		store := gcsstore.New(Flags.GCSBucket, Flags.GCSObjectPrefix, service)
 		store.UseIn(Composer)
 
 		locker := memorylocker.New()

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -18,6 +18,7 @@ var Flags struct {
 	S3ObjectPrefix    string
 	S3Endpoint        string
 	GCSBucket         string
+	GCSObjectPrefix   string
 	FileHooksDir      string
 	HttpHooksEndpoint string
 	HttpHooksRetry    int
@@ -44,6 +45,7 @@ func ParseFlags() {
 	flag.StringVar(&Flags.S3ObjectPrefix, "s3-object-prefix", "", "Prefix for S3 object names")
 	flag.StringVar(&Flags.S3Endpoint, "s3-endpoint", "", "Endpoint to use S3 compatible implementations like minio (requires s3-bucket to be pass)")
 	flag.StringVar(&Flags.GCSBucket, "gcs-bucket", "", "Use Google Cloud Storage with this bucket as storage backend (requires the GCS_SERVICE_ACCOUNT_FILE environment variable to be set)")
+	flag.StringVar(&Flags.GCSObjectPrefix, "gcs-object-prefix", "", "Prefix for GCS object names")
 	flag.StringVar(&Flags.FileHooksDir, "hooks-dir", "", "Directory to search for available hooks scripts")
 	flag.StringVar(&Flags.HttpHooksEndpoint, "hooks-http", "", "An HTTP endpoint to which hook events will be sent to")
 	flag.IntVar(&Flags.HttpHooksRetry, "hooks-http-retry", 3, "Number of times to retry on a 500 or network timeout")

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"path/filepath"
+	"strings"
 )
 
 var Flags struct {
@@ -45,7 +46,7 @@ func ParseFlags() {
 	flag.StringVar(&Flags.S3ObjectPrefix, "s3-object-prefix", "", "Prefix for S3 object names")
 	flag.StringVar(&Flags.S3Endpoint, "s3-endpoint", "", "Endpoint to use S3 compatible implementations like minio (requires s3-bucket to be pass)")
 	flag.StringVar(&Flags.GCSBucket, "gcs-bucket", "", "Use Google Cloud Storage with this bucket as storage backend (requires the GCS_SERVICE_ACCOUNT_FILE environment variable to be set)")
-	flag.StringVar(&Flags.GCSObjectPrefix, "gcs-object-prefix", "", "Prefix for GCS object names")
+	flag.StringVar(&Flags.GCSObjectPrefix, "gcs-object-prefix", "", "Prefix for GCS object names (can't contain underscore character)")
 	flag.StringVar(&Flags.FileHooksDir, "hooks-dir", "", "Directory to search for available hooks scripts")
 	flag.StringVar(&Flags.HttpHooksEndpoint, "hooks-http", "", "An HTTP endpoint to which hook events will be sent to")
 	flag.IntVar(&Flags.HttpHooksRetry, "hooks-http-retry", 3, "Number of times to retry on a 500 or network timeout")
@@ -75,5 +76,10 @@ func ParseFlags() {
 			"(using -s3-bucket) must be specified to start tusd but " +
 			"neither flag was provided. Please consult `tusd -help` for " +
 			"more information on these options.")
+	}
+
+	if Flags.GCSObjectPrefix != "" && strings.Contains(Flags.GCSObjectPrefix, "_") {
+		stderr.Fatalf("gcs-object-prefix value (%s) can't contain underscore. "+
+			"Please remove underscore from the value", Flags.GCSObjectPrefix)
 	}
 }

--- a/gcsstore/gcsstore.go
+++ b/gcsstore/gcsstore.go
@@ -45,10 +45,11 @@ type GCSStore struct {
 
 // New constructs a new GCS storage backend using the supplied GCS bucket name
 // and service object.
-func New(bucket string, service GCSAPI) GCSStore {
+func New(bucket string, objPrefix string, service GCSAPI) GCSStore {
 	return GCSStore{
-		Bucket:  bucket,
-		Service: service,
+		Bucket:       bucket,
+		ObjectPrefix: objPrefix,
+		Service:      service,
 	}
 }
 

--- a/gcsstore/gcsstore.go
+++ b/gcsstore/gcsstore.go
@@ -14,12 +14,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/net/context"
 	"io"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	"golang.org/x/net/context"
 
 	"cloud.google.com/go/storage"
 	"github.com/tus/tusd"
@@ -31,6 +32,11 @@ import (
 type GCSStore struct {
 	// Specifies the GCS bucket that uploads will be stored in
 	Bucket string
+
+	// ObjectPrefix is prepended to the name of each GCS object that is created.
+	// It can be used to create a pseudo-directory structure in the bucket,
+	// e.g. "path/to/my/uploads".
+	ObjectPrefix string
 
 	// Service specifies an interface used to communicate with the Google
 	// cloud storage backend. Implementation can be seen in gcsservice file.

--- a/gcsstore/gcsstore.go
+++ b/gcsstore/gcsstore.go
@@ -45,10 +45,9 @@ type GCSStore struct {
 
 // New constructs a new GCS storage backend using the supplied GCS bucket name
 // and service object.
-func New(bucket string, objPrefix string, service GCSAPI) GCSStore {
+func New(bucket string, service GCSAPI) GCSStore {
 	return GCSStore{
 		Bucket:       bucket,
-		ObjectPrefix: objPrefix,
 		Service:      service,
 	}
 }

--- a/gcsstore/gcsstore_test.go
+++ b/gcsstore/gcsstore_test.go
@@ -20,7 +20,6 @@ import (
 
 const mockID = "123456789abcdefghijklmnopqrstuvwxyz"
 const mockBucket = "bucket"
-const mockObjPrefix = ""
 const mockSize = 1337
 const mockReaderData = "helloworld"
 
@@ -44,7 +43,7 @@ func TestNewUpload(t *testing.T) {
 	assert := assert.New(t)
 
 	service := NewMockGCSAPI(mockCtrl)
-	store := gcsstore.New(mockBucket, mockObjPrefix, service)
+	store := gcsstore.New(mockBucket, service)
 
 	assert.Equal(store.Bucket, mockBucket)
 
@@ -95,7 +94,7 @@ func TestGetInfo(t *testing.T) {
 	assert := assert.New(t)
 
 	service := NewMockGCSAPI(mockCtrl)
-	store := gcsstore.New(mockBucket, mockObjPrefix, service)
+	store := gcsstore.New(mockBucket, service)
 
 	assert.Equal(store.Bucket, mockBucket)
 
@@ -158,7 +157,7 @@ func TestGetInfoNotFound(t *testing.T) {
 	assert := assert.New(t)
 
 	service := NewMockGCSAPI(mockCtrl)
-	store := gcsstore.New(mockBucket, mockObjPrefix, service)
+	store := gcsstore.New(mockBucket, service)
 
 	params := gcsstore.GCSObjectParams{
 		Bucket: store.Bucket,
@@ -203,7 +202,7 @@ func TestGetReader(t *testing.T) {
 	assert := assert.New(t)
 
 	service := NewMockGCSAPI(mockCtrl)
-	store := gcsstore.New(mockBucket, mockObjPrefix, service)
+	store := gcsstore.New(mockBucket, service)
 
 	assert.Equal(store.Bucket, mockBucket)
 
@@ -232,7 +231,7 @@ func TestTerminate(t *testing.T) {
 	assert := assert.New(t)
 
 	service := NewMockGCSAPI(mockCtrl)
-	store := gcsstore.New(mockBucket, mockObjPrefix, service)
+	store := gcsstore.New(mockBucket, service)
 
 	assert.Equal(store.Bucket, mockBucket)
 
@@ -254,7 +253,7 @@ func TestFinishUpload(t *testing.T) {
 	assert := assert.New(t)
 
 	service := NewMockGCSAPI(mockCtrl)
-	store := gcsstore.New(mockBucket, mockObjPrefix, service)
+	store := gcsstore.New(mockBucket, service)
 
 	assert.Equal(store.Bucket, mockBucket)
 
@@ -373,7 +372,7 @@ func TestWriteChunk(t *testing.T) {
 	assert := assert.New(t)
 
 	service := NewMockGCSAPI(mockCtrl)
-	store := gcsstore.New(mockBucket, mockObjPrefix, service)
+	store := gcsstore.New(mockBucket, service)
 
 	assert.Equal(store.Bucket, mockBucket)
 

--- a/gcsstore/gcsstore_test.go
+++ b/gcsstore/gcsstore_test.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/net/context"
 	"testing"
+
+	"golang.org/x/net/context"
 
 	"cloud.google.com/go/storage"
 	"github.com/golang/mock/gomock"
@@ -19,6 +20,7 @@ import (
 
 const mockID = "123456789abcdefghijklmnopqrstuvwxyz"
 const mockBucket = "bucket"
+const mockObjPrefix = ""
 const mockSize = 1337
 const mockReaderData = "helloworld"
 
@@ -42,7 +44,7 @@ func TestNewUpload(t *testing.T) {
 	assert := assert.New(t)
 
 	service := NewMockGCSAPI(mockCtrl)
-	store := gcsstore.New(mockBucket, service)
+	store := gcsstore.New(mockBucket, mockObjPrefix, service)
 
 	assert.Equal(store.Bucket, mockBucket)
 
@@ -93,7 +95,7 @@ func TestGetInfo(t *testing.T) {
 	assert := assert.New(t)
 
 	service := NewMockGCSAPI(mockCtrl)
-	store := gcsstore.New(mockBucket, service)
+	store := gcsstore.New(mockBucket, mockObjPrefix, service)
 
 	assert.Equal(store.Bucket, mockBucket)
 
@@ -156,7 +158,7 @@ func TestGetInfoNotFound(t *testing.T) {
 	assert := assert.New(t)
 
 	service := NewMockGCSAPI(mockCtrl)
-	store := gcsstore.New(mockBucket, service)
+	store := gcsstore.New(mockBucket, mockObjPrefix, service)
 
 	params := gcsstore.GCSObjectParams{
 		Bucket: store.Bucket,
@@ -201,7 +203,7 @@ func TestGetReader(t *testing.T) {
 	assert := assert.New(t)
 
 	service := NewMockGCSAPI(mockCtrl)
-	store := gcsstore.New(mockBucket, service)
+	store := gcsstore.New(mockBucket, mockObjPrefix, service)
 
 	assert.Equal(store.Bucket, mockBucket)
 
@@ -230,7 +232,7 @@ func TestTerminate(t *testing.T) {
 	assert := assert.New(t)
 
 	service := NewMockGCSAPI(mockCtrl)
-	store := gcsstore.New(mockBucket, service)
+	store := gcsstore.New(mockBucket, mockObjPrefix, service)
 
 	assert.Equal(store.Bucket, mockBucket)
 
@@ -252,7 +254,7 @@ func TestFinishUpload(t *testing.T) {
 	assert := assert.New(t)
 
 	service := NewMockGCSAPI(mockCtrl)
-	store := gcsstore.New(mockBucket, service)
+	store := gcsstore.New(mockBucket, mockObjPrefix, service)
 
 	assert.Equal(store.Bucket, mockBucket)
 
@@ -371,7 +373,7 @@ func TestWriteChunk(t *testing.T) {
 	assert := assert.New(t)
 
 	service := NewMockGCSAPI(mockCtrl)
-	store := gcsstore.New(mockBucket, service)
+	store := gcsstore.New(mockBucket, mockObjPrefix, service)
 
 	assert.Equal(store.Bucket, mockBucket)
 


### PR DESCRIPTION
reference : #213 

since prefixing object name available in s3 object, i think its good to be able to prefix object name in gcs too.
thanks @acj for making that so i can replicate it for GCS store