### PR TITLE
Add timestamps to tusd log 

### DIFF
--- a/config.go
+++ b/config.go
@@ -47,8 +47,7 @@ type Config struct {
 
 func (config *Config) validate() error {
 	if config.Logger == nil {
-		config.Logger = log.New(os.Stdout, "[tusd] ", 0)
-		config.Logger.SetFlags(log.Ldate | log.Lmicroseconds)
+		config.Logger = log.New(os.Stdout, "[tusd] ", log.Ldate | log.Lmicroseconds)
 	}
 
 	base := config.BasePath

--- a/config.go
+++ b/config.go
@@ -48,6 +48,7 @@ type Config struct {
 func (config *Config) validate() error {
 	if config.Logger == nil {
 		config.Logger = log.New(os.Stdout, "[tusd] ", 0)
+		config.Logger.SetFlags(log.Ldate | log.Lmicroseconds)
 	}
 
 	base := config.BasePath


### PR DESCRIPTION
This PR adds timestamps to tusd logger. 

The following line is modified https://github.com/tus/tusd/blob/master/config.go#L50 by setting the timestamp flags to the Log config

```go
 if config.Logger == nil {
	config.Logger = log.New(os.Stdout, "[tusd] ", log.Ldate | log.Lmicroseconds)
 }
```

Flags log.Ldate | log.Lmicroseconds are used producing this kind of log line

```
 [tusd] 2019/05/24 11:39:18.827952 event="RequestIncoming" method="HEAD" path="..."
```

Closes #274 