### PR TITLE
Add original request to info to be passed to hooks

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -2,6 +2,7 @@ package tusd
 
 import (
 	"io"
+	"net/http"
 
 	"golang.org/x/net/context"
 )
@@ -27,7 +28,8 @@ type FileInfo struct {
 	// ordered slice containing the ids of the uploads of which the final upload
 	// will consist after concatenation.
 	PartialUploads []string
-
+	// The original http request initiating this FileInfo instance
+	OriginalRequest OriginalRequest
 	// stopUpload is the cancel function for the upload's context.Context. When
 	// invoked it will interrupt the writes to DataStore#WriteChunk.
 	stopUpload context.CancelFunc
@@ -42,6 +44,14 @@ func (f FileInfo) StopUpload() {
 	if f.stopUpload != nil {
 		f.stopUpload()
 	}
+}
+
+type OriginalRequest struct {
+	Host       string
+	Proto      string
+	RequestURI string
+	RemoteAddr string
+	Headers    http.Header
 }
 
 type DataStore interface {

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -13,7 +13,7 @@ If not otherwise noted, all hooks are invoked in a *non-blocking* way, meaning t
 
 ## Blocking Hooks
 
-On the other hand, there are a few *blocking* hooks, such as caused by the `pre-create` event. Because their exit code will dictate whether tusd will accept the current incoming request, tusd will wait until the hook process has exited. Therefore, in order to keep the response times low, one should avoid to make time-consuming operations inside the processes for blocking hooks. 
+On the other hand, there are a few *blocking* hooks, such as caused by the `pre-create` event. Because their exit code will dictate whether tusd will accept the current incoming request, tusd will wait until the hook process has exited. Therefore, in order to keep the response times low, one should avoid to make time-consuming operations inside the processes for blocking hooks.
 
 ### Blocking File Hooks
 
@@ -31,7 +31,7 @@ This event will be triggered before an upload is created, allowing you to run ce
 
 ### post-create
 
-This event will be triggered after an upload is created, allowing you to run certain routines. For example, notifying other parts of your system that a new upload has to be handled. At this point the upload may have received some data already since the invocation of these hooks may be delayed by a short duration. 
+This event will be triggered after an upload is created, allowing you to run certain routines. For example, notifying other parts of your system that a new upload has to be handled. At this point the upload may have received some data already since the invocation of these hooks may be delayed by a short duration.
 
 ### post-finish
 
@@ -88,6 +88,38 @@ The process of the hook files are provided with information about the event and 
   // trust it without escaping it first!
   "MetaData": {
     "filename": "transloadit.png"
+  },
+  "OriginalRequest": {
+    "Headers": {
+      "Accept": [
+        "*/*"
+      ],
+      "Accept-Encoding": [
+        "gzip, deflate"
+      ],
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Length": [
+        "0"
+      ],
+      "Tus-Resumable": [
+        "1.0.0"
+      ],
+      "Upload-Length": [
+        "9216959"
+      ],
+      "Upload-Metadata": [
+        "filename dHJhbnNsb2FkaXQucG5n"
+      ],
+      "User-Agent": [
+        "python-requests/2.20.1"
+      ]
+    },
+    "RemoteAddr": "127.0.0.1:58383",
+    "Proto": "HTTP/1.1",
+    "RequestURI": "/files/",
+    "Host": "localhost:1080"
   }
 }
 ```
@@ -138,6 +170,38 @@ Tusd will issue a `POST` request to the specified URL endpoint, specifying the h
   // trust it without escaping it first!
   "MetaData": {
     "filename": "transloadit.png"
+  },
+  "OriginalRequest": {
+    "Headers": {
+      "Accept": [
+        "*/*"
+      ],
+      "Accept-Encoding": [
+        "gzip, deflate"
+      ],
+      "Connection": [
+        "keep-alive"
+      ],
+      "Content-Length": [
+        "0"
+      ],
+      "Tus-Resumable": [
+        "1.0.0"
+      ],
+      "Upload-Length": [
+        "9216959"
+      ],
+      "Upload-Metadata": [
+        "filename dHJhbnNsb2FkaXQucG5n"
+      ],
+      "User-Agent": [
+        "python-requests/2.20.1"
+      ]
+    },
+    "RemoteAddr": "127.0.0.1:58383",
+    "Proto": "HTTP/1.1",
+    "RequestURI": "/files/",
+    "Host": "localhost:1080"
   }
 }
 ```

--- a/s3store/s3store_test.go
+++ b/s3store/s3store_test.go
@@ -53,8 +53,8 @@ func TestNewUpload(t *testing.T) {
 		s3obj.EXPECT().PutObject(&s3.PutObjectInput{
 			Bucket:        aws.String("bucket"),
 			Key:           aws.String("uploadId.info"),
-			Body:          bytes.NewReader([]byte(`{"ID":"uploadId+multipartId","Size":500,"SizeIsDeferred":false,"Offset":0,"MetaData":{"bar":"menü","foo":"hello"},"IsPartial":false,"IsFinal":false,"PartialUploads":null}`)),
-			ContentLength: aws.Int64(int64(171)),
+			Body:          bytes.NewReader([]byte(`{"ID":"uploadId+multipartId","Size":500,"SizeIsDeferred":false,"Offset":0,"MetaData":{"bar":"menü","foo":"hello"},"IsPartial":false,"IsFinal":false,"PartialUploads":null,"OriginalRequest":{"Host":"","Proto":"","RequestURI":"","RemoteAddr":"","Headers":null}}`)),
+			ContentLength: aws.Int64(int64(259)),
 		}),
 	)
 
@@ -101,8 +101,8 @@ func TestNewUploadWithObjectPrefix(t *testing.T) {
 		s3obj.EXPECT().PutObject(&s3.PutObjectInput{
 			Bucket:        aws.String("bucket"),
 			Key:           aws.String("my/uploaded/files/uploadId.info"),
-			Body:          bytes.NewReader([]byte(`{"ID":"uploadId+multipartId","Size":500,"SizeIsDeferred":false,"Offset":0,"MetaData":{"bar":"menü","foo":"hello"},"IsPartial":false,"IsFinal":false,"PartialUploads":null}`)),
-			ContentLength: aws.Int64(int64(171)),
+			Body:          bytes.NewReader([]byte(`{"ID":"uploadId+multipartId","Size":500,"SizeIsDeferred":false,"Offset":0,"MetaData":{"bar":"menü","foo":"hello"},"IsPartial":false,"IsFinal":false,"PartialUploads":null,"OriginalRequest":{"Host":"","Proto":"","RequestURI":"","RemoteAddr":"","Headers":null}}`)),
+			ContentLength: aws.Int64(int64(259)),
 		}),
 	)
 
@@ -243,8 +243,8 @@ func TestGetInfoWithIncompletePart(t *testing.T) {
 			Bucket: aws.String("bucket"),
 			Key:    aws.String("uploadId.part"),
 		}).Return(&s3.GetObjectOutput{
-			ContentLength: 	aws.Int64(10),
-			Body: 			ioutil.NopCloser(bytes.NewReader([]byte("0123456789"))),
+			ContentLength: aws.Int64(10),
+			Body:          ioutil.NopCloser(bytes.NewReader([]byte("0123456789"))),
 		}, nil),
 	)
 
@@ -387,8 +387,8 @@ func TestDeclareLength(t *testing.T) {
 		s3obj.EXPECT().PutObject(&s3.PutObjectInput{
 			Bucket:        aws.String("bucket"),
 			Key:           aws.String("uploadId.info"),
-			Body:          bytes.NewReader([]byte(`{"ID":"uploadId+multipartId","Size":500,"SizeIsDeferred":false,"Offset":0,"MetaData":{},"IsPartial":false,"IsFinal":false,"PartialUploads":null}`)),
-			ContentLength: aws.Int64(int64(144)),
+			Body:          bytes.NewReader([]byte(`{"ID":"uploadId+multipartId","Size":500,"SizeIsDeferred":false,"Offset":0,"MetaData":{},"IsPartial":false,"IsFinal":false,"PartialUploads":null,"OriginalRequest":{"Host":"","Proto":"","RequestURI":"","RemoteAddr":"","Headers":null}}`)),
+			ContentLength: aws.Int64(int64(232)),
 		}),
 	)
 
@@ -730,8 +730,8 @@ func TestWriteChunkPrependsIncompletePart(t *testing.T) {
 			Bucket: aws.String("bucket"),
 			Key:    aws.String("uploadId.part"),
 		}).Return(&s3.GetObjectOutput{
-			ContentLength: 	aws.Int64(3),
-			Body:			ioutil.NopCloser(bytes.NewReader([]byte("123"))),
+			ContentLength: aws.Int64(3),
+			Body:          ioutil.NopCloser(bytes.NewReader([]byte("123"))),
 		}, nil),
 		s3obj.EXPECT().ListParts(&s3.ListPartsInput{
 			Bucket:           aws.String("bucket"),

--- a/utils_test.go
+++ b/utils_test.go
@@ -79,6 +79,14 @@ func (test *httpTest) Run(handler http.Handler, t *testing.T) *httptest.Response
 	return w
 }
 
+func toHTTPHeader(headerMap map[string]string) http.Header {
+	header := http.Header{}
+	for key, value := range headerMap {
+		header.Set(key, value)
+	}
+	return header
+}
+
 type readerMatcher struct {
 	expect string
 }


### PR DESCRIPTION
Implements passing the original request to hooks. closes https://github.com/tus/tusd/issues/185

Review appreciated, not sure if approach is correct but couldn't see a better place to add the OriginalRequest except to the FileInfo since that's what's being sent to the hooks - the alternative would be to create a separate channel for hooks which seemed like overkill.

Example payload - maybe should remove some of those tus headers like`Upload-Metadata` as they are redundant?
```json
{
  "ID": "",
  "Size": 626,
  "SizeIsDeferred": false,
  "Offset": 0,
  "MetaData": {
    "content_type": "text/plain",
    "filename": "README.md"
  },
  "IsPartial": false,
  "IsFinal": false,
  "PartialUploads": null,
  "OriginalRequest": {
    "Host": "localhost:1080",
    "Proto": "HTTP/1.1",
    "RequestURI": "/files/",
    "RemoteAddr": "127.0.0.1:58512",
    "Headers": {
      "Accept": [
        "*/*"
      ],
      "Accept-Encoding": [
        "gzip, deflate"
      ],
      "Connection": [
        "keep-alive"
      ],
      "Content-Length": [
        "0"
      ],
      "Tus-Resumable": [
        "1.0.0"
      ],
      "Upload-Length": [
        "626"
      ],
      "Upload-Metadata": [
        "content_type dGV4dC9wbGFpbg==,filename UkVBRE1FLm1k"
      ],
      "User-Agent": [
        "python-requests/2.20.1"
      ]
    }
  }
}
```