### PR TITLE
Set the docker user to tusd.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,3 +33,5 @@ WORKDIR /srv/tusd-data
 EXPOSE 1080
 ENTRYPOINT ["tusd"]
 CMD ["--hooks-dir","/srv/tusd-hooks"]
+
+USER tusd


### PR DESCRIPTION
User tusd has been created but is not selected for the tusd process within the container. Fixed in this Dockerfile.