### PR TITLE
Installing gcc and libc-dev for having a matching gcc and linker in the image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/tus/tusd/
 WORKDIR /go/src/github.com/tus/tusd
 
 RUN apk add --no-cache \
-        git \
+        git gcc libc-dev \
     && go get -d -v ./... \
     && version="$(git tag -l --points-at HEAD)" \
     && commit=$(git log --format="%H" -n 1) \


### PR DESCRIPTION
This fixes the issues with the docker build process.