### PR TITLE
Updated docker from alpine 3.8 to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache \
     && apk del git
 
 # start a new stage that copies in the binary built in the previous stage
-FROM alpine:3.8
+FROM alpine:3.9
 
 COPY --from=builder /go/bin/tusd /usr/local/bin/tusd
 


### PR DESCRIPTION
Updated the base image to use the current alpine version which is supported until 2020-11-01 (https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases)