### PR TITLE
[FIX] s3store residual temp files

### DIFF
--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -259,8 +259,8 @@ func (store S3Store) WriteChunk(id string, offset int64, src io.Reader) (int64, 
 		return 0, err
 	}
 	if incompletePartFile != nil {
-		defer incompletePartFile.Close()
 		defer os.Remove(incompletePartFile.Name())
+		defer incompletePartFile.Close()
 
 		if err := store.deleteIncompletePartForUpload(uploadId); err != nil {
 			return 0, err


### PR DESCRIPTION
Hi :)

When s3store is used in the os temp folder there are `tusd-s3-tmp*` files accumulating space.

The problem was in the WriteChunk method incompletePartFile must close it before remove it.

This was fixed in one line :)