### PR TITLE
S3 multipart id fix

### DIFF
--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -517,6 +517,18 @@ func (store S3Store) FinishUpload(id string) error {
 			Parts: completedParts,
 		},
 	})
+	if err != nil {
+		return err
+	}
+
+	// rewrite ID field in .info metadata file to contain only upload id
+	info, err := store.GetInfo(id)
+	if err != nil {
+		return err
+	}
+
+	info.ID = uploadId
+	err = store.writeInfo(uploadId, info)
 
 	return err
 }

--- a/unrouted_handler.go
+++ b/unrouted_handler.go
@@ -326,6 +326,10 @@ func (handler *UnroutedHandler) PostFile(w http.ResponseWriter, r *http.Request)
 		info.Offset = size
 
 		if handler.config.NotifyCompleteUploads {
+			// strip multipartupload identifier from upload identifier (s3 storage)
+			if strings.Contains(info.ID, "+") {
+				info.ID = strings.Split(info.ID, "+")[0]
+			}
 			handler.CompleteUploads <- info
 		}
 	}
@@ -609,6 +613,10 @@ func (handler *UnroutedHandler) finishUploadIfComplete(info FileInfo) error {
 
 		// ... send the info out to the channel
 		if handler.config.NotifyCompleteUploads {
+			// strip multipartupload identifier from upload identifier (s3 storage)
+			if strings.Contains(info.ID, "+") {
+				info.ID = strings.Split(info.ID, "+")[0]
+			}
 			handler.CompleteUploads <- info
 		}
 


### PR DESCRIPTION
The upload identifier of a completed upload, when tusd is configured to use s3 as storage backend, will look like `${upload_identifier}+${multipart_identifier}` (I am using the following [script](https://gist.github.com/arbakker/4d7b0870d5f62f87ff13c40589788023) to create the upload). The upload identifier (the field `ID`) is returned both returned in the `.info` metadata file and the JSON payload of the webhooks:

```json
{
    "ID": "832839f804c60eb680525504c12df04b+5054f51f-3722-441c-b9cd-64e59d22dfae",
    "Size": 2656287,
    "SizeIsDeferred": false,
    "Offset": 2656287,
    "MetaData": {
        "filename": "my_file.something"
    },
    "IsPartial": false,
    "IsFinal": false,
    "PartialUploads": null
}
```

When using local file storage as storage backend the `ID` field only contains the upload-identifier (`${upload_identifier}`). According to this [comment](https://github.com/tus/tusd/issues/173#issuecomment-377012396), the multipart identifier is of no use after the upload is finished. In conclusion; this seems like a bug to me. 

Included in the pull request is fix for this behavior and contains checks whether the identifier contains a multipart id and strips it (only when the upload completes). The fix also rewrites `.info` file after the upload is completed, to strip the multipart id from the the `.info` file.