### PR TITLE
Whitelist hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Usage of tusd:
     	Use Google Cloud Storage with this bucket as storage backend (requires the GCS_SERVICE_ACCOUNT_FILE environment variable to be set)
   -hooks-dir string
     	Directory to search for available hooks scripts
+  -hooks-enabled-events string
+    	Comma separated list of enabled hook events, set to "-" to disable all (default "*")
   -hooks-http string
     	An HTTP endpoint to which hook events will be sent to
   -hooks-http-backoff int

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -107,10 +107,18 @@ func ParseFlags() {
 }
 
 func SetEnabledHooks() {
+	var InvalidHooks []string
 	if Flags.EnabledHooks != "" {
 		slc := strings.Split(Flags.EnabledHooks, ",")
 		for i, h := range slc {
 			slc[i] = strings.TrimSpace(h)
+		}
+
+		// check if enabled hook strings are valid
+		for _, h := range slc {
+			if !hookTypeInSlice(hooks.HookType(h), hooks.AvailableHooks) {
+				InvalidHooks = append(InvalidHooks, h)
+			}
 		}
 
 		for _, h := range hooks.AvailableHooks {
@@ -131,5 +139,8 @@ func SetEnabledHooks() {
 		EnabledHooksString = append(EnabledHooksString, string(h))
 	}
 
+	if len(InvalidHooks) > 0 {
+		stdout.Printf("Invalid hook events in hooks-enabled-events option: %s", strings.Join(InvalidHooks[:], ", "))
+	}
 	stdout.Printf("Enabled hook events: %s", strings.Join(EnabledHooksString[:], ", "))
 }

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"path/filepath"
 	"strings"
+
+	"github.com/tus/tusd/cmd/tusd/cli/hooks"
 )
 
 var Flags struct {
@@ -20,6 +22,7 @@ var Flags struct {
 	S3Endpoint          string
 	GCSBucket           string
 	GCSObjectPrefix     string
+	EnabledHooks        string
 	FileHooksDir        string
 	HttpHooksEndpoint   string
 	HttpHooksRetry      int
@@ -33,6 +36,17 @@ var Flags struct {
 
 	FileHooksInstalled bool
 	HttpHooksInstalled bool
+}
+
+var EnabledHooks map[hooks.HookType]bool
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
 }
 
 func ParseFlags() {
@@ -49,6 +63,7 @@ func ParseFlags() {
 	flag.StringVar(&Flags.S3Endpoint, "s3-endpoint", "", "Endpoint to use S3 compatible implementations like minio (requires s3-bucket to be pass)")
 	flag.StringVar(&Flags.GCSBucket, "gcs-bucket", "", "Use Google Cloud Storage with this bucket as storage backend (requires the GCS_SERVICE_ACCOUNT_FILE environment variable to be set)")
 	flag.StringVar(&Flags.GCSObjectPrefix, "gcs-object-prefix", "", "Prefix for GCS object names (can't contain underscore character)")
+	flag.StringVar(&Flags.EnabledHooks, "enabled-hooks", "", "List of enabled hook events")
 	flag.StringVar(&Flags.FileHooksDir, "hooks-dir", "", "Directory to search for available hooks scripts")
 	flag.StringVar(&Flags.HttpHooksEndpoint, "hooks-http", "", "An HTTP endpoint to which hook events will be sent to")
 	flag.IntVar(&Flags.HttpHooksRetry, "hooks-http-retry", 3, "Number of times to retry on a 500 or network timeout")
@@ -59,8 +74,42 @@ func ParseFlags() {
 	flag.BoolVar(&Flags.ExposeMetrics, "expose-metrics", true, "Expose metrics about tusd usage")
 	flag.StringVar(&Flags.MetricsPath, "metrics-path", "/metrics", "Path under which the metrics endpoint will be accessible")
 	flag.BoolVar(&Flags.BehindProxy, "behind-proxy", false, "Respect X-Forwarded-* and similar headers which may be set by proxies")
-
 	flag.Parse()
+
+	EnabledHooks = make(map[hooks.HookType]bool)
+	if Flags.EnabledHooks != "*" && Flags.EnabledHooks != "" {
+		slc := strings.Split(Flags.EnabledHooks, ",")
+		for i := range slc {
+			slc[i] = strings.TrimSpace(slc[i])
+		}
+		if stringInSlice("post-finish", slc) {
+			EnabledHooks[hooks.HookPostFinish] = true
+		}
+		if stringInSlice("post-create", slc) {
+			EnabledHooks[hooks.HookPostCreate] = true
+		}
+		if stringInSlice("post-terminate", slc) {
+			EnabledHooks[hooks.HookPostTerminate] = true
+		}
+		if stringInSlice("post-receive", slc) {
+			EnabledHooks[hooks.HookPostReceive] = true
+		}
+		if stringInSlice("pre-create", slc) {
+			EnabledHooks[hooks.HookPreCreate] = true
+		}
+	} else if Flags.EnabledHooks == "*" {
+		EnabledHooks[hooks.HookPreCreate] = true
+		EnabledHooks[hooks.HookPostTerminate] = true
+		EnabledHooks[hooks.HookPostReceive] = true
+		EnabledHooks[hooks.HookPostCreate] = true
+		EnabledHooks[hooks.HookPostFinish] = true
+	} else if Flags.EnabledHooks == "" {
+		EnabledHooks[hooks.HookPreCreate] = false
+		EnabledHooks[hooks.HookPostTerminate] = false
+		EnabledHooks[hooks.HookPostReceive] = false
+		EnabledHooks[hooks.HookPostCreate] = false
+		EnabledHooks[hooks.HookPostFinish] = false
+	}
 
 	if Flags.FileHooksDir != "" {
 		Flags.FileHooksDir, _ = filepath.Abs(Flags.FileHooksDir)

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -106,7 +106,19 @@ func ParseFlags() {
 
 func SetEnabledHooks() {
 	EnabledHooks = make(map[hooks.HookType]bool)
-	if Flags.EnabledHooks != "*" && Flags.EnabledHooks != "-" {
+	if Flags.EnabledHooks == "*" {
+		EnabledHooks[hooks.HookPreCreate] = true
+		EnabledHooks[hooks.HookPostTerminate] = true
+		EnabledHooks[hooks.HookPostReceive] = true
+		EnabledHooks[hooks.HookPostCreate] = true
+		EnabledHooks[hooks.HookPostFinish] = true
+	} else if Flags.EnabledHooks == "-" {
+		EnabledHooks[hooks.HookPreCreate] = false
+		EnabledHooks[hooks.HookPostTerminate] = false
+		EnabledHooks[hooks.HookPostReceive] = false
+		EnabledHooks[hooks.HookPostCreate] = false
+		EnabledHooks[hooks.HookPostFinish] = false
+	} else {
 		slc := strings.Split(Flags.EnabledHooks, ",")
 		for i := range slc {
 			slc[i] = strings.TrimSpace(slc[i])
@@ -126,18 +138,6 @@ func SetEnabledHooks() {
 		if stringInSlice("pre-create", slc) {
 			EnabledHooks[hooks.HookPreCreate] = true
 		}
-	} else if Flags.EnabledHooks == "*" {
-		EnabledHooks[hooks.HookPreCreate] = true
-		EnabledHooks[hooks.HookPostTerminate] = true
-		EnabledHooks[hooks.HookPostReceive] = true
-		EnabledHooks[hooks.HookPostCreate] = true
-		EnabledHooks[hooks.HookPostFinish] = true
-	} else if Flags.EnabledHooks == "-" {
-		EnabledHooks[hooks.HookPreCreate] = false
-		EnabledHooks[hooks.HookPostTerminate] = false
-		EnabledHooks[hooks.HookPostReceive] = false
-		EnabledHooks[hooks.HookPostCreate] = false
-		EnabledHooks[hooks.HookPostFinish] = false
 	}
 	stringHooks := ""
 	for k, v := range EnabledHooks {

--- a/cmd/tusd/cli/hooks.go
+++ b/cmd/tusd/cli/hooks.go
@@ -99,7 +99,7 @@ func invokeHookAsync(typ hooks.HookType, info tusd.FileInfo) {
 }
 
 func invokeHookSync(typ hooks.HookType, info tusd.FileInfo, captureOutput bool) ([]byte, error) {
-	if hookTypeInSlice(typ, EnabledHooks) {
+	if !hookTypeInSlice(typ, EnabledHooks) {
 		return nil, nil
 	}
 

--- a/cmd/tusd/cli/hooks.go
+++ b/cmd/tusd/cli/hooks.go
@@ -62,7 +62,6 @@ func SetupPreHooks(composer *tusd.StoreComposer) error {
 	composer.UseCore(hookDataStore{
 		DataStore: composer.Core,
 	})
-
 	return nil
 }
 
@@ -91,6 +90,10 @@ func invokeHookAsync(typ hooks.HookType, info tusd.FileInfo) {
 }
 
 func invokeHookSync(typ hooks.HookType, info tusd.FileInfo, captureOutput bool) ([]byte, error) {
+	if !EnabledHooks[typ] {
+		return nil, nil
+	}
+
 	switch typ {
 	case hooks.HookPostFinish:
 		logEv(stdout, "UploadFinished", "id", info.ID, "size", strconv.FormatInt(info.Size, 10))

--- a/cmd/tusd/cli/hooks.go
+++ b/cmd/tusd/cli/hooks.go
@@ -10,6 +10,15 @@ import (
 
 var hookHandler hooks.HookHandler = nil
 
+func hookTypeInSlice(a hooks.HookType, list []hooks.HookType) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
 type hookDataStore struct {
 	tusd.DataStore
 }
@@ -90,7 +99,7 @@ func invokeHookAsync(typ hooks.HookType, info tusd.FileInfo) {
 }
 
 func invokeHookSync(typ hooks.HookType, info tusd.FileInfo, captureOutput bool) ([]byte, error) {
-	if !EnabledHooks[typ] {
+	if hookTypeInSlice(typ, EnabledHooks) {
 		return nil, nil
 	}
 

--- a/cmd/tusd/cli/hooks/hooks.go
+++ b/cmd/tusd/cli/hooks/hooks.go
@@ -19,6 +19,8 @@ const (
 	HookPreCreate     HookType = "pre-create"
 )
 
+var AvailableHooks []HookType = []HookType{HookPreCreate, HookPostCreate, HookPostReceive, HookPostTerminate, HookPostFinish}
+
 type hookDataStore struct {
 	tusd.DataStore
 }

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -45,15 +45,9 @@ This event will be triggered after an upload has been terminated, meaning that t
 
 This event will be triggered for every running upload to indicate its current progress. It will be emitted whenever the server has received more data from the client but at most every second. The offset property will be set to the number of bytes which have been transfered to the server, at the time in total. Please be aware that this number may be higher than the number of bytes which have been stored by the data store!
 
-## Enabling/Disabling Hook Events
+## Whitelisting Hook Events
 
-The `--hooks-enabled-events` option for the tusd binary works as a whitelist for hook events and takes a comma separated list of hook events. By default all hook events are enabled.
-
-Possible values for the `--hooks-enabled-events` option:
-
-- `*` - enable all hook events (default value)
-- `""` - disable all hook events
-- comma separated list of hook events (for instance: `pre-create,post-create`) - whitelist of hook events
+The `--hooks-enabled-events` option for the tusd binary works as a whitelist for hook events and takes a comma separated list of hook events (for instance: `pre-create,post-create`). If the `--hooks-enabled-events` option is omitted, all hook events are enabled.
 
 ## File Hooks
 ### The Hook Directory

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -52,7 +52,7 @@ The `--hooks-enabled-events` option for the tusd binary works as a whitelist for
 Possible values for the `--hooks-enabled-events` option:
 
 - `*` - enable all hook events (default value)
-- `-` - disable all hook events
+- `""` - disable all hook events
 - comma separated list of hook events (for instance: `pre-create,post-create`) - whitelist of hook events
 
 ## File Hooks

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -45,6 +45,15 @@ This event will be triggered after an upload has been terminated, meaning that t
 
 This event will be triggered for every running upload to indicate its current progress. It will be emitted whenever the server has received more data from the client but at most every second. The offset property will be set to the number of bytes which have been transfered to the server, at the time in total. Please be aware that this number may be higher than the number of bytes which have been stored by the data store!
 
+## Enabling/Disabling Hook Events
+
+The `--hooks-enabled-events` option for the tusd binary works as a whitelist for hook events and takes a comma separated list of hook events. By default all hook events are enabled.
+
+Possible values for the `--hooks-enabled-events` option:
+
+- `*` - enable all hook events (default value)
+- `-` - disable all hook events
+- comma separated list of hook events (for instance: `pre-create,post-create`) - whitelist of hook events
 
 ## File Hooks
 ### The Hook Directory


### PR DESCRIPTION
Implemented cli option to for hooks whitelisting, based on this [comment](https://github.com/tus/tusd/pull/240#issuecomment-461571470). I named the cli option `hooks-enabled-events` so it is consistent with the other `hooks` options.  I added the following docs to the `docs/hooks.md` in the pull request:

<hr>
## Enabling/Disabling Hook Events

The `--hooks-enabled-events` option for the tusd binary works as a whitelist for hook events and takes a comma separated list of hook events. By default all hook events are enabled.

Possible values for the `--hooks-enabled-events` option:

- `*` - enable all hook events (default value)
- `""` - disable all hook events
- comma separated list of hook events (for instance: `pre-create,post-create`) - whitelist of hook events
<hr>

Feedback on the code quality is more than welcome, I am still quite new to Go. 