### PR TITLE
Update deprecated methods

### DIFF
--- a/pkg/gcsstore/gcsservice.go
+++ b/pkg/gcsstore/gcsservice.go
@@ -77,10 +77,10 @@ type GCSService struct {
 	Client *storage.Client
 }
 
-// NewGCSService returns a GCSSerivce object given a GCloud service account file path.
+// NewGCSService returns a GCSService object given a GCloud service account file path.
 func NewGCSService(filename string) (*GCSService, error) {
 	ctx := context.Background()
-	client, err := storage.NewClient(ctx, option.WithServiceAccountFile(filename))
+	client, err := storage.NewClient(ctx, option.WithCredentialsFile(filename))
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +269,7 @@ func (service *GCSService) ReadObject(ctx context.Context, params GCSObjectParam
 	return r, nil
 }
 
-// SetObjectMetadata reads a GCSObjectParams and a map of metedata, returning a nil on sucess and an error otherwise
+// SetObjectMetadata reads a GCSObjectParams and a map of metadata, returning a nil on success and an error otherwise
 func (service *GCSService) SetObjectMetadata(ctx context.Context, params GCSObjectParams, metadata map[string]string) error {
 	attrs := storage.ObjectAttrsToUpdate{
 		Metadata: metadata,
@@ -324,11 +324,11 @@ func (service *GCSService) ComposeFrom(ctx context.Context, objSrcs []*storage.O
 	return dstAttrs.CRC32C, nil
 }
 
-// FilterObjects retuns a list of GCS object IDs that match the passed GCSFilterParams.
+// FilterObjects returns a list of GCS object IDs that match the passed GCSFilterParams.
 // It expects GCS objects to be of the format [uid]_[chunk_idx] where chunk_idx
 // is zero based. The format [uid]_tmp_[recursion_lvl]_[chunk_idx] can also be used to
 // specify objects that have been composed in a recursive fashion. These different formats
-// are usedd to ensure that objects are composed in the correct order.
+// are used to ensure that objects are composed in the correct order.
 func (service *GCSService) FilterObjects(ctx context.Context, params GCSFilterParams) ([]string, error) {
 	bkt := service.Client.Bucket(params.Bucket)
 	q := storage.Query{
@@ -384,6 +384,6 @@ loop:
 
 		names[idx] = objAttrs.Name
 	}
-	return names, nil
 
+	return names, nil
 }

--- a/pkg/handler/cors_test.go
+++ b/pkg/handler/cors_test.go
@@ -59,19 +59,19 @@ func TestCORS(t *testing.T) {
 		req.Host = "tus.io"
 
 		res := httptest.NewRecorder()
-		res.HeaderMap.Set("Access-Control-Allow-Headers", "HEADER")
-		res.HeaderMap.Set("Access-Control-Allow-Methods", "METHOD")
+		res.Header().Set("Access-Control-Allow-Headers", "HEADER")
+		res.Header().Set("Access-Control-Allow-Methods", "METHOD")
 		handler.ServeHTTP(res, req)
 
-		headers := res.HeaderMap["Access-Control-Allow-Headers"]
-		methods := res.HeaderMap["Access-Control-Allow-Methods"]
+		headers := res.Header()["Access-Control-Allow-Headers"]
+		methods := res.Header()["Access-Control-Allow-Methods"]
 
 		if headers[0] != "HEADER" {
 			t.Errorf("expected header to contain HEADER but got: %#v", headers)
 		}
 
 		if methods[0] != "METHOD" {
-			t.Errorf("expected header to contain HEADER but got: %#v", methods)
+			t.Errorf("expected header to contain METHOD but got: %#v", methods)
 		}
 	})
 }

--- a/pkg/handler/utils_test.go
+++ b/pkg/handler/utils_test.go
@@ -75,7 +75,7 @@ func (test *httpTest) Run(handler http.Handler, t *testing.T) *httptest.Response
 	}
 
 	for key, value := range test.ResHeader {
-		header := w.HeaderMap.Get(key)
+		header := w.Header().Get(key)
 
 		if value != header {
 			t.Errorf("Expected '%s' as '%s' (got '%s')", value, key, header)


### PR DESCRIPTION
This PR:
- Replaces deprecated GCS [WithServiceAccountFile](https://godoc.org/google.golang.org/api/option#WithServiceAccountFile) with [WithCredentialsFile](https://godoc.org/google.golang.org/api/option#WithCredentialsFile).
- Replaces deprecated [ResponseRecorder HeaderMap](https://golang.org/pkg/net/http/httptest/#ResponseRecorder) with [Header()](https://golang.org/pkg/net/http/httptest/#ResponseRecorder.Header).
- Fixes some typos.