### PR TITLE
filestore.NewUpload: Remove useless defer

### DIFF
--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -65,7 +65,10 @@ func (store FileStore) NewUpload(ctx context.Context, info handler.FileInfo) (ha
 		}
 		return nil, err
 	}
-	defer file.Close()
+	err = file.Close()
+	if err != nil {
+		return nil, err
+	}
 
 	upload := &fileUpload{
 		info:     info,


### PR DESCRIPTION
Since the `file` is not used after the creation, its closing can be done without defer (and the err can be checked).