### PR TITLE
S3Store: Apply tags to temporary S3 objects

### DIFF
--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -273,6 +273,7 @@ func (upload *s3Upload) writeInfo(ctx context.Context, info handler.FileInfo) er
 		Key:           store.keyWithPrefix(uploadId + ".info"),
 		Body:          bytes.NewReader(infoJson),
 		ContentLength: aws.Int64(int64(len(infoJson))),
+		Tagging:       aws.String(store.TransientObjectTags),
 	})
 
 	return err
@@ -723,9 +724,10 @@ func (store S3Store) getIncompletePartForUpload(ctx context.Context, uploadId st
 
 func (store S3Store) putIncompletePartForUpload(ctx context.Context, uploadId string, r io.ReadSeeker) error {
 	_, err := store.Service.PutObjectWithContext(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(store.Bucket),
-		Key:    store.keyWithPrefix(uploadId + ".part"),
-		Body:   r,
+		Bucket:  aws.String(store.Bucket),
+		Key:     store.keyWithPrefix(uploadId + ".part"),
+		Tagging: aws.String(store.TransientObjectTags),
+		Body:    r,
 	})
 	return err
 }

--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -132,6 +132,15 @@ type S3Store struct {
 	// MaxObjectSize is the maximum size an S3 Object can have according to S3
 	// API specifications. See link above.
 	MaxObjectSize int64
+	// TransientObjectTags is a comma-separated list of tags that is applied to tus
+	// metadata objects that can be safely deleted after an upload is complete, such
+	// as .info and .part objects. Each tag is a key-value pair, e.g. "mykey=myvalue".
+	// This mechanism can be used to create an S3 object lifecycle policy that
+	// removes such objects after a period of time.
+	// See:
+	//   - https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html
+	//   - https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html
+	TransientObjectTags string
 }
 
 type S3API interface {

--- a/pkg/s3store/s3store_test.go
+++ b/pkg/s3store/s3store_test.go
@@ -36,16 +36,13 @@ func TestNewUpload(t *testing.T) {
 	assert.Equal("bucket", store.Bucket)
 	assert.Equal(s3obj, store.Service)
 
-	s1 := "hello"
-	s2 := "men???hi"
-
 	gomock.InOrder(
 		s3obj.EXPECT().CreateMultipartUploadWithContext(context.Background(), &s3.CreateMultipartUploadInput{
 			Bucket: aws.String("bucket"),
 			Key:    aws.String("uploadId"),
 			Metadata: map[string]*string{
-				"foo": &s1,
-				"bar": &s2,
+				"foo": aws.String("hello"),
+				"bar": aws.String("men???hi"),
 			},
 		}).Return(&s3.CreateMultipartUploadOutput{
 			UploadId: aws.String("multipartId"),
@@ -85,16 +82,13 @@ func TestNewUploadWithObjectPrefix(t *testing.T) {
 	assert.Equal("bucket", store.Bucket)
 	assert.Equal(s3obj, store.Service)
 
-	s1 := "hello"
-	s2 := "men?"
-
 	gomock.InOrder(
 		s3obj.EXPECT().CreateMultipartUploadWithContext(context.Background(), &s3.CreateMultipartUploadInput{
 			Bucket: aws.String("bucket"),
 			Key:    aws.String("my/uploaded/files/uploadId"),
 			Metadata: map[string]*string{
-				"foo": &s1,
-				"bar": &s2,
+				"foo": aws.String("hello"),
+				"bar": aws.String("men?"),
 			},
 		}).Return(&s3.CreateMultipartUploadOutput{
 			UploadId: aws.String("multipartId"),
@@ -156,16 +150,13 @@ func TestNewUploadWithTransientTags(t *testing.T) {
 	assert.Equal("bucket", store.Bucket)
 	assert.Equal(s3obj, store.Service)
 
-	s1 := "hello"
-	s2 := "men???hi"
-
 	gomock.InOrder(
 		s3obj.EXPECT().CreateMultipartUploadWithContext(context.Background(), &s3.CreateMultipartUploadInput{
 			Bucket: aws.String("bucket"),
 			Key:    aws.String("uploadId"),
 			Metadata: map[string]*string{
-				"foo": &s1,
-				"bar": &s2,
+				"foo": aws.String("hello"),
+				"bar": aws.String("men???hi"),
 			},
 		}).Return(&s3.CreateMultipartUploadOutput{
 			UploadId: aws.String("multipartId"),


### PR DESCRIPTION
tusd's temporary metadata objects (.info, .part, etc) can become a maintenance burden for certain applications. For example, applications may place uploaded objects directly into their final bucket in order to avoid slow copy operations. However, this means that the metadata objects are also placed in the same bucket. This can confuse automated tools and creates a nontrivial amount of cruft in the bucket over time.

This PR introduces an optional `TransientObjectTags` field on S3Store that takes a comma-separated list of [tags](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html) to be applied to tusd's metadata objects. By tagging these objects, tusd operators can define an [S3 object lifecycle policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) that automatically removes the objects after a period of time.

I still need to test a handful of edge cases, but this is ready for general feedback.

The initial discussion for this feature is in #219.