### PR TITLE
S3Store: Add optional key prefix for metadata objects

### DIFF
--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -804,3 +804,15 @@ func (store S3Store) keyWithPrefix(key string) *string {
 
 	return aws.String(prefix + key)
 }
+
+func (store S3Store) metadataKeyWithPrefix(key string) *string {
+	prefix := store.MetadataObjectPrefix
+	if prefix == "" {
+		prefix = store.ObjectPrefix
+	}
+	if prefix != "" && !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	return aws.String(prefix + key)
+}

--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -264,7 +264,7 @@ func (upload *s3Upload) writeInfo(ctx context.Context, info handler.FileInfo) er
 	// Create object on S3 containing information about the file
 	_, err = store.Service.PutObjectWithContext(ctx, &s3.PutObjectInput{
 		Bucket:        aws.String(store.Bucket),
-		Key:           store.keyWithPrefix(uploadId + ".info"),
+		Key:           store.metadataKeyWithPrefix(uploadId + ".info"),
 		Body:          bytes.NewReader(infoJson),
 		ContentLength: aws.Int64(int64(len(infoJson))),
 	})
@@ -398,7 +398,7 @@ func (upload s3Upload) fetchInfo(ctx context.Context) (info handler.FileInfo, er
 	// Get file info stored in separate object
 	res, err := store.Service.GetObjectWithContext(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(store.Bucket),
-		Key:    store.keyWithPrefix(uploadId + ".info"),
+		Key:    store.metadataKeyWithPrefix(uploadId + ".info"),
 	})
 	if err != nil {
 		if isAwsError(err, "NoSuchKey") {
@@ -524,10 +524,10 @@ func (upload s3Upload) Terminate(ctx context.Context) error {
 						Key: store.keyWithPrefix(uploadId),
 					},
 					{
-						Key: store.keyWithPrefix(uploadId + ".part"),
+						Key: store.metadataKeyWithPrefix(uploadId + ".part"),
 					},
 					{
-						Key: store.keyWithPrefix(uploadId + ".info"),
+						Key: store.metadataKeyWithPrefix(uploadId + ".info"),
 					},
 				},
 				Quiet: aws.Bool(true),
@@ -705,7 +705,7 @@ func (store S3Store) downloadIncompletePartForUpload(ctx context.Context, upload
 func (store S3Store) getIncompletePartForUpload(ctx context.Context, uploadId string) (*s3.GetObjectOutput, error) {
 	obj, err := store.Service.GetObjectWithContext(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(store.Bucket),
-		Key:    store.keyWithPrefix(uploadId + ".part"),
+		Key:    store.metadataKeyWithPrefix(uploadId + ".part"),
 	})
 
 	if err != nil && (isAwsError(err, s3.ErrCodeNoSuchKey) || isAwsError(err, "NotFound") || isAwsError(err, "AccessDenied")) {
@@ -718,7 +718,7 @@ func (store S3Store) getIncompletePartForUpload(ctx context.Context, uploadId st
 func (store S3Store) putIncompletePartForUpload(ctx context.Context, uploadId string, r io.ReadSeeker) error {
 	_, err := store.Service.PutObjectWithContext(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(store.Bucket),
-		Key:    store.keyWithPrefix(uploadId + ".part"),
+		Key:    store.metadataKeyWithPrefix(uploadId + ".part"),
 		Body:   r,
 	})
 	return err
@@ -727,7 +727,7 @@ func (store S3Store) putIncompletePartForUpload(ctx context.Context, uploadId st
 func (store S3Store) deleteIncompletePartForUpload(ctx context.Context, uploadId string) error {
 	_, err := store.Service.DeleteObjectWithContext(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(store.Bucket),
-		Key:    store.keyWithPrefix(uploadId + ".part"),
+		Key:    store.metadataKeyWithPrefix(uploadId + ".part"),
 	})
 	return err
 }

--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -105,6 +105,9 @@ type S3Store struct {
 	// It can be used to create a pseudo-directory structure in the bucket,
 	// e.g. "path/to/my/uploads".
 	ObjectPrefix string
+	// MetadataObjectPrefix is prepended to the name of each .info and .part S3
+	// object that is created. If it is not set, then ObjectPrefix is used.
+	MetadataObjectPrefix string
 	// Service specifies an interface used to communicate with the S3 backend.
 	// Usually, this is an instance of github.com/aws/aws-sdk-go/service/s3.S3
 	// (http://docs.aws.amazon.com/sdk-for-go/api/service/s3/S3.html).

--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -101,9 +101,9 @@ var nonASCIIRegexp = regexp.MustCompile(`([^\x00-\x7F]|[\r\n])`)
 type S3Store struct {
 	// Bucket used to store the data in, e.g. "tusdstore.example.com"
 	Bucket string
-	// ObjectPrefix is prepended to the name of each S3 object that is created.
-	// It can be used to create a pseudo-directory structure in the bucket,
-	// e.g. "path/to/my/uploads".
+	// ObjectPrefix is prepended to the name of each S3 object that is created
+	// to store uploaded files. It can be used to create a pseudo-directory
+	// structure in the bucket, e.g. "path/to/my/uploads".
 	ObjectPrefix string
 	// MetadataObjectPrefix is prepended to the name of each .info and .part S3
 	// object that is created. If it is not set, then ObjectPrefix is used.


### PR DESCRIPTION
As discussed in #336, this is a simpler approach to support automatic cleanup of metadata objects.

tusd's temporary metadata objects (.info, .part, etc) can become a maintenance burden for certain applications. For example, applications may place uploaded objects directly into their final bucket in order to avoid slow copy operations. However, this means that the metadata objects are also placed in the same bucket. This can confuse automated tools and creates a nontrivial amount of cruft in the bucket over time.

This PR introduces a `MetadataObjectPrefix` field that, when set, will be applied instead of `ObjectPrefix` for .info and .part objects. By providing a separate object prefix, tusd operators can define an [S3 object lifecycle policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) that automatically removes the metadata objects after a period of time.

The tests that I added should verify the metadata prefix with each type of object -- uploads, .info, and .part. Please let me know if any more coverage is needed.