### PR TITLE
Add request context to handler contexts

### DIFF
--- a/pkg/handler/context_test.go
+++ b/pkg/handler/context_test.go
@@ -1,0 +1,35 @@
+package handler_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	. "github.com/tus/tusd/pkg/handler"
+)
+
+type testCtxKey string
+
+func TestRequestContext(t *testing.T) {
+
+	rctx := context.WithValue(context.Background(), testCtxKey("foo"), "bar")
+	ctx := context.Background()
+
+	wrapped := SetRequestContext(ctx, rctx)
+
+	tctx := RequestContext(wrapped)
+	if tctx == nil {
+		t.Error("should return rctx")
+	}
+
+	if !reflect.DeepEqual(rctx, tctx) {
+		t.Error("did not return rctx")
+	}
+
+	v := tctx.Value(testCtxKey("foo"))
+	if s, ok := v.(string); !ok {
+		t.Errorf("context value not string; got: %T", v)
+	} else if s != "bar" {
+		t.Errorf("context value somehow changed; got: %s", s)
+	}
+}

--- a/pkg/handler/cors_test.go
+++ b/pkg/handler/cors_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -26,7 +27,7 @@ func TestCORS(t *testing.T) {
 				"Access-Control-Max-Age":       "86400",
 				"Access-Control-Allow-Origin":  "tus.io",
 			},
-		}).Run(handler, t)
+		}).Run(context.Background(), handler, t)
 	})
 
 	SubTest(t, "Request", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
@@ -45,7 +46,7 @@ func TestCORS(t *testing.T) {
 				"Access-Control-Expose-Headers": "Upload-Offset, Location, Upload-Length, Tus-Version, Tus-Resumable, Tus-Max-Size, Tus-Extension, Upload-Metadata, Upload-Defer-Length, Upload-Concat",
 				"Access-Control-Allow-Origin":   "tus.io",
 			},
-		}).Run(handler, t)
+		}).Run(context.Background(), handler, t)
 	})
 
 	SubTest(t, "AppendHeaders", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {

--- a/pkg/handler/options_test.go
+++ b/pkg/handler/options_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -26,7 +27,7 @@ func TestOptions(t *testing.T) {
 				"Tus-Max-Size":  "400",
 			},
 			Code: http.StatusOK,
-		}).Run(handler, t)
+		}).Run(context.Background(), handler, t)
 	})
 
 	SubTest(t, "InvalidVersion", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
@@ -40,6 +41,6 @@ func TestOptions(t *testing.T) {
 				"Tus-Resumable": "foo",
 			},
 			Code: http.StatusPreconditionFailed,
-		}).Run(handler, t)
+		}).Run(context.Background(), handler, t)
 	})
 }

--- a/pkg/handler/patch_test.go
+++ b/pkg/handler/patch_test.go
@@ -22,15 +22,17 @@ func TestPatch(t *testing.T) {
 		defer ctrl.Finish()
 		upload := NewMockFullUpload(ctrl)
 
+		ctx := context.Background()
+
 		gomock.InOrder(
-			store.EXPECT().GetUpload(context.Background(), "yes").Return(upload, nil),
-			upload.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+			store.EXPECT().GetUpload(SetRequestContext(context.Background(), ctx), "yes").Return(upload, nil),
+			upload.EXPECT().GetInfo(SetRequestContext(context.Background(), ctx)).Return(FileInfo{
 				ID:     "yes",
 				Offset: 5,
 				Size:   10,
 			}, nil),
-			upload.EXPECT().WriteChunk(context.Background(), int64(5), NewReaderMatcher("hello")).Return(int64(5), nil),
-			upload.EXPECT().FinishUpload(context.Background()),
+			upload.EXPECT().WriteChunk(SetRequestContext(context.Background(), ctx), int64(5), NewReaderMatcher("hello")).Return(int64(5), nil),
+			upload.EXPECT().FinishUpload(SetRequestContext(context.Background(), ctx)),
 		)
 
 		handler, _ := NewHandler(Config{
@@ -54,7 +56,7 @@ func TestPatch(t *testing.T) {
 			ResHeader: map[string]string{
 				"Upload-Offset": "10",
 			},
-		}).Run(handler, t)
+		}).Run(ctx, handler, t)
 
 		a := assert.New(t)
 		event := <-c
@@ -74,15 +76,17 @@ func TestPatch(t *testing.T) {
 		defer ctrl.Finish()
 		upload := NewMockFullUpload(ctrl)
 
+		ctx := context.Background()
+
 		gomock.InOrder(
-			store.EXPECT().GetUpload(context.Background(), "yes").Return(upload, nil),
-			upload.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+			store.EXPECT().GetUpload(SetRequestContext(context.Background(), ctx), "yes").Return(upload, nil),
+			upload.EXPECT().GetInfo(SetRequestContext(context.Background(), ctx)).Return(FileInfo{
 				ID:     "yes",
 				Offset: 5,
 				Size:   10,
 			}, nil),
-			upload.EXPECT().WriteChunk(context.Background(), int64(5), NewReaderMatcher("hello")).Return(int64(5), nil),
-			upload.EXPECT().FinishUpload(context.Background()),
+			upload.EXPECT().WriteChunk(SetRequestContext(context.Background(), ctx), int64(5), NewReaderMatcher("hello")).Return(int64(5), nil),
+			upload.EXPECT().FinishUpload(SetRequestContext(context.Background(), ctx)),
 		)
 
 		handler, _ := NewHandler(Config{
@@ -103,7 +107,7 @@ func TestPatch(t *testing.T) {
 			ResHeader: map[string]string{
 				"Upload-Offset": "10",
 			},
-		}).Run(handler, t)
+		}).Run(ctx, handler, t)
 	})
 
 	SubTest(t, "UploadChunkToFinished", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
@@ -111,9 +115,11 @@ func TestPatch(t *testing.T) {
 		defer ctrl.Finish()
 		upload := NewMockFullUpload(ctrl)
 
+		ctx := context.Background()
+
 		gomock.InOrder(
-			store.EXPECT().GetUpload(context.Background(), "yes").Return(upload, nil),
-			upload.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+			store.EXPECT().GetUpload(SetRequestContext(context.Background(), ctx), "yes").Return(upload, nil),
+			upload.EXPECT().GetInfo(SetRequestContext(context.Background(), ctx)).Return(FileInfo{
 				ID:     "yes",
 				Offset: 20,
 				Size:   20,
@@ -137,11 +143,12 @@ func TestPatch(t *testing.T) {
 			ResHeader: map[string]string{
 				"Upload-Offset": "20",
 			},
-		}).Run(handler, t)
+		}).Run(ctx, handler, t)
 	})
 
 	SubTest(t, "UploadNotFoundFail", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
-		store.EXPECT().GetUpload(context.Background(), "no").Return(nil, os.ErrNotExist)
+		ctx := context.Background()
+		store.EXPECT().GetUpload(SetRequestContext(context.Background(), ctx), "no").Return(nil, os.ErrNotExist)
 
 		handler, _ := NewHandler(Config{
 			StoreComposer: composer,
@@ -156,7 +163,7 @@ func TestPatch(t *testing.T) {
 				"Upload-Offset": "5",
 			},
 			Code: http.StatusNotFound,
-		}).Run(handler, t)
+		}).Run(ctx, handler, t)
 	})
 
 	SubTest(t, "MissmatchingOffsetFail", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
@@ -164,9 +171,11 @@ func TestPatch(t *testing.T) {
 		defer ctrl.Finish()
 		upload := NewMockFullUpload(ctrl)
 
+		ctx := context.Background()
+
 		gomock.InOrder(
-			store.EXPECT().GetUpload(context.Background(), "yes").Return(upload, nil),
-			upload.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+			store.EXPECT().GetUpload(SetRequestContext(context.Background(), ctx), "yes").Return(upload, nil),
+			upload.EXPECT().GetInfo(SetRequestContext(context.Background(), ctx)).Return(FileInfo{
 				ID:     "yes",
 				Offset: 5,
 			}, nil),
@@ -185,7 +194,7 @@ func TestPatch(t *testing.T) {
 				"Upload-Offset": "4",
 			},
 			Code: http.StatusConflict,
-		}).Run(handler, t)
+		}).Run(ctx, handler, t)
 	})
 
 	SubTest(t, "ExceedingMaxSizeFail", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
@@ -193,9 +202,11 @@ func TestPatch(t *testing.T) {
 		defer ctrl.Finish()
 		upload := NewMockFullUpload(ctrl)
 
+		ctx := context.Background()
+
 		gomock.InOrder(
-			store.EXPECT().GetUpload(context.Background(), "yes").Return(upload, nil),
-			upload.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+			store.EXPECT().GetUpload(SetRequestContext(context.Background(), ctx), "yes").Return(upload, nil),
+			upload.EXPECT().GetInfo(SetRequestContext(context.Background(), ctx)).Return(FileInfo{
 				ID:     "yes",
 				Offset: 5,
 				Size:   10,
@@ -216,7 +227,7 @@ func TestPatch(t *testing.T) {
 			},
 			ReqBody: strings.NewReader("hellothisismorethan15bytes"),
 			Code:    http.StatusRequestEntityTooLarge,
-		}).Run(handler, t)
+		}).Run(ctx, handler, t)
 	})
 
 	SubTest(t, "InvalidContentTypeFail", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
@@ -234,7 +245,7 @@ func TestPatch(t *testing.T) {
 			},
 			ReqBody: strings.NewReader("hellothisismorethan15bytes"),
 			Code:    http.StatusBadRequest,
-		}).Run(handler, t)
+		}).Run(context.Background(), handler, t)
 	})
 
 	SubTest(t, "InvalidOffsetFail", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
@@ -252,7 +263,7 @@ func TestPatch(t *testing.T) {
 			},
 			ReqBody: strings.NewReader("hellothisismorethan15bytes"),
 			Code:    http.StatusBadRequest,
-		}).Run(handler, t)
+		}).Run(context.Background(), handler, t)
 	})
 
 	SubTest(t, "OverflowWithoutLength", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
@@ -267,15 +278,17 @@ func TestPatch(t *testing.T) {
 		defer ctrl.Finish()
 		upload := NewMockFullUpload(ctrl)
 
+		ctx := context.Background()
+
 		gomock.InOrder(
-			store.EXPECT().GetUpload(context.Background(), "yes").Return(upload, nil),
-			upload.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+			store.EXPECT().GetUpload(SetRequestContext(context.Background(), ctx), "yes").Return(upload, nil),
+			upload.EXPECT().GetInfo(SetRequestContext(context.Background(), ctx)).Return(FileInfo{
 				ID:     "yes",
 				Offset: 5,
 				Size:   20,
 			}, nil),
-			upload.EXPECT().WriteChunk(context.Background(), int64(5), NewReaderMatcher("hellothisismore")).Return(int64(15), nil),
-			upload.EXPECT().FinishUpload(context.Background()),
+			upload.EXPECT().WriteChunk(SetRequestContext(context.Background(), ctx), int64(5), NewReaderMatcher("hellothisismore")).Return(int64(15), nil),
+			upload.EXPECT().FinishUpload(SetRequestContext(context.Background(), ctx)),
 		)
 
 		handler, _ := NewHandler(Config{
@@ -301,7 +314,7 @@ func TestPatch(t *testing.T) {
 			ResHeader: map[string]string{
 				"Upload-Offset": "20",
 			},
-		}).Run(handler, t)
+		}).Run(ctx, handler, t)
 	})
 
 	SubTest(t, "DeclareLengthOnFinalChunk", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
@@ -309,18 +322,20 @@ func TestPatch(t *testing.T) {
 		defer ctrl.Finish()
 		upload := NewMockFullUpload(ctrl)
 
+		ctx := context.Background()
+
 		gomock.InOrder(
-			store.EXPECT().GetUpload(context.Background(), "yes").Return(upload, nil),
-			upload.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+			store.EXPECT().GetUpload(SetRequestContext(context.Background(), ctx), "yes").Return(upload, nil),
+			upload.EXPECT().GetInfo(SetRequestContext(context.Background(), ctx)).Return(FileInfo{
 				ID:             "yes",
 				Offset:         5,
 				Size:           0,
 				SizeIsDeferred: true,
 			}, nil),
 			store.EXPECT().AsLengthDeclarableUpload(upload).Return(upload),
-			upload.EXPECT().DeclareLength(context.Background(), int64(20)),
-			upload.EXPECT().WriteChunk(context.Background(), int64(5), NewReaderMatcher("hellothisismore")).Return(int64(15), nil),
-			upload.EXPECT().FinishUpload(context.Background()),
+			upload.EXPECT().DeclareLength(SetRequestContext(context.Background(), ctx), int64(20)),
+			upload.EXPECT().WriteChunk(SetRequestContext(context.Background(), ctx), int64(5), NewReaderMatcher("hellothisismore")).Return(int64(15), nil),
+			upload.EXPECT().FinishUpload(SetRequestContext(context.Background(), ctx)),
 		)
 
 		handler, _ := NewHandler(Config{
@@ -344,7 +359,7 @@ func TestPatch(t *testing.T) {
 			ResHeader: map[string]string{
 				"Upload-Offset": "20",
 			},
-		}).Run(handler, t)
+		}).Run(ctx, handler, t)
 	})
 
 	SubTest(t, "DeclareLengthAfterFinalChunk", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
@@ -352,17 +367,19 @@ func TestPatch(t *testing.T) {
 		defer ctrl.Finish()
 		upload := NewMockFullUpload(ctrl)
 
+		ctx := context.Background()
+
 		gomock.InOrder(
-			store.EXPECT().GetUpload(context.Background(), "yes").Return(upload, nil),
-			upload.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+			store.EXPECT().GetUpload(SetRequestContext(context.Background(), ctx), "yes").Return(upload, nil),
+			upload.EXPECT().GetInfo(SetRequestContext(context.Background(), ctx)).Return(FileInfo{
 				ID:             "yes",
 				Offset:         20,
 				Size:           0,
 				SizeIsDeferred: true,
 			}, nil),
 			store.EXPECT().AsLengthDeclarableUpload(upload).Return(upload),
-			upload.EXPECT().DeclareLength(context.Background(), int64(20)),
-			upload.EXPECT().FinishUpload(context.Background()),
+			upload.EXPECT().DeclareLength(SetRequestContext(context.Background(), ctx), int64(20)),
+			upload.EXPECT().FinishUpload(SetRequestContext(context.Background(), ctx)),
 		)
 
 		handler, _ := NewHandler(Config{
@@ -382,7 +399,7 @@ func TestPatch(t *testing.T) {
 			ReqBody:   nil,
 			Code:      http.StatusNoContent,
 			ResHeader: map[string]string{},
-		}).Run(handler, t)
+		}).Run(ctx, handler, t)
 	})
 
 	SubTest(t, "DeclareLengthOnNonFinalChunk", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
@@ -391,27 +408,29 @@ func TestPatch(t *testing.T) {
 		upload1 := NewMockFullUpload(ctrl)
 		upload2 := NewMockFullUpload(ctrl)
 
+		ctx := context.Background()
+
 		gomock.InOrder(
-			store.EXPECT().GetUpload(context.Background(), "yes").Return(upload1, nil),
-			upload1.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+			store.EXPECT().GetUpload(SetRequestContext(context.Background(), ctx), "yes").Return(upload1, nil),
+			upload1.EXPECT().GetInfo(SetRequestContext(context.Background(), ctx)).Return(FileInfo{
 				ID:             "yes",
 				Offset:         5,
 				Size:           0,
 				SizeIsDeferred: true,
 			}, nil),
 			store.EXPECT().AsLengthDeclarableUpload(upload1).Return(upload1),
-			upload1.EXPECT().DeclareLength(context.Background(), int64(20)),
-			upload1.EXPECT().WriteChunk(context.Background(), int64(5), NewReaderMatcher("hello")).Return(int64(5), nil),
+			upload1.EXPECT().DeclareLength(SetRequestContext(context.Background(), ctx), int64(20)),
+			upload1.EXPECT().WriteChunk(SetRequestContext(context.Background(), ctx), int64(5), NewReaderMatcher("hello")).Return(int64(5), nil),
 
-			store.EXPECT().GetUpload(context.Background(), "yes").Return(upload2, nil),
-			upload2.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+			store.EXPECT().GetUpload(SetRequestContext(context.Background(), ctx), "yes").Return(upload2, nil),
+			upload2.EXPECT().GetInfo(SetRequestContext(context.Background(), ctx)).Return(FileInfo{
 				ID:             "yes",
 				Offset:         10,
 				Size:           20,
 				SizeIsDeferred: false,
 			}, nil),
-			upload2.EXPECT().WriteChunk(context.Background(), int64(10), NewReaderMatcher("thisismore")).Return(int64(10), nil),
-			upload2.EXPECT().FinishUpload(context.Background()),
+			upload2.EXPECT().WriteChunk(SetRequestContext(context.Background(), ctx), int64(10), NewReaderMatcher("thisismore")).Return(int64(10), nil),
+			upload2.EXPECT().FinishUpload(SetRequestContext(context.Background(), ctx)),
 		)
 
 		handler, _ := NewHandler(Config{
@@ -433,7 +452,7 @@ func TestPatch(t *testing.T) {
 			ResHeader: map[string]string{
 				"Upload-Offset": "10",
 			},
-		}).Run(handler, t)
+		}).Run(ctx, handler, t)
 
 		(&httpTest{
 			Method: "PATCH",
@@ -448,7 +467,7 @@ func TestPatch(t *testing.T) {
 			ResHeader: map[string]string{
 				"Upload-Offset": "20",
 			},
-		}).Run(handler, t)
+		}).Run(ctx, handler, t)
 	})
 
 	SubTest(t, "Locker", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
@@ -458,16 +477,18 @@ func TestPatch(t *testing.T) {
 		lock := NewMockFullLock(ctrl)
 		upload := NewMockFullUpload(ctrl)
 
+		ctx := context.Background()
+
 		gomock.InOrder(
 			locker.EXPECT().NewLock("yes").Return(lock, nil),
 			lock.EXPECT().Lock().Return(nil),
-			store.EXPECT().GetUpload(context.Background(), "yes").Return(upload, nil),
-			upload.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+			store.EXPECT().GetUpload(SetRequestContext(context.Background(), ctx), "yes").Return(upload, nil),
+			upload.EXPECT().GetInfo(SetRequestContext(context.Background(), ctx)).Return(FileInfo{
 				ID:     "yes",
 				Offset: 0,
 				Size:   20,
 			}, nil),
-			upload.EXPECT().WriteChunk(context.Background(), int64(0), NewReaderMatcher("hello")).Return(int64(5), nil),
+			upload.EXPECT().WriteChunk(SetRequestContext(context.Background(), ctx), int64(0), NewReaderMatcher("hello")).Return(int64(5), nil),
 			lock.EXPECT().Unlock().Return(nil),
 		)
 
@@ -489,7 +510,7 @@ func TestPatch(t *testing.T) {
 			},
 			ReqBody: strings.NewReader("hello"),
 			Code:    http.StatusNoContent,
-		}).Run(handler, t)
+		}).Run(ctx, handler, t)
 	})
 
 	SubTest(t, "NotifyUploadProgress", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
@@ -497,14 +518,16 @@ func TestPatch(t *testing.T) {
 		defer ctrl.Finish()
 		upload := NewMockFullUpload(ctrl)
 
+		ctx := context.Background()
+
 		gomock.InOrder(
-			store.EXPECT().GetUpload(context.Background(), "yes").Return(upload, nil),
-			upload.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+			store.EXPECT().GetUpload(SetRequestContext(context.Background(), ctx), "yes").Return(upload, nil),
+			upload.EXPECT().GetInfo(SetRequestContext(context.Background(), ctx)).Return(FileInfo{
 				ID:     "yes",
 				Offset: 0,
 				Size:   100,
 			}, nil),
-			upload.EXPECT().WriteChunk(context.Background(), int64(0), NewReaderMatcher("first second third")).Return(int64(18), nil),
+			upload.EXPECT().WriteChunk(SetRequestContext(context.Background(), ctx), int64(0), NewReaderMatcher("first second third")).Return(int64(18), nil),
 		)
 
 		handler, _ := NewHandler(Config{
@@ -555,7 +578,7 @@ func TestPatch(t *testing.T) {
 			ResHeader: map[string]string{
 				"Upload-Offset": "18",
 			},
-		}).Run(handler, t)
+		}).Run(ctx, handler, t)
 
 		// Wait a short time after the request has been handled before closing the
 		// channel because another goroutine may still write to the channel.
@@ -571,16 +594,18 @@ func TestPatch(t *testing.T) {
 		defer ctrl.Finish()
 		upload := NewMockFullUpload(ctrl)
 
+		ctx := context.Background()
+
 		gomock.InOrder(
-			store.EXPECT().GetUpload(context.Background(), "yes").Return(upload, nil),
-			upload.EXPECT().GetInfo(context.Background()).Return(FileInfo{
+			store.EXPECT().GetUpload(SetRequestContext(context.Background(), ctx), "yes").Return(upload, nil),
+			upload.EXPECT().GetInfo(SetRequestContext(context.Background(), ctx)).Return(FileInfo{
 				ID:     "yes",
 				Offset: 0,
 				Size:   100,
 			}, nil),
-			upload.EXPECT().WriteChunk(context.Background(), int64(0), NewReaderMatcher("first ")).Return(int64(6), http.ErrBodyReadAfterClose),
+			upload.EXPECT().WriteChunk(SetRequestContext(context.Background(), ctx), int64(0), NewReaderMatcher("first ")).Return(int64(6), http.ErrBodyReadAfterClose),
 			store.EXPECT().AsTerminatableUpload(upload).Return(upload),
-			upload.EXPECT().Terminate(context.Background()),
+			upload.EXPECT().Terminate(SetRequestContext(context.Background(), ctx)),
 		)
 
 		handler, _ := NewHandler(Config{
@@ -627,7 +652,7 @@ func TestPatch(t *testing.T) {
 			ResHeader: map[string]string{
 				"Upload-Offset": "",
 			},
-		}).Run(handler, t)
+		}).Run(ctx, handler, t)
 
 		_, more := <-c
 		a.False(more)

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -121,7 +121,9 @@ func RequestContext(ctx context.Context) context.Context {
 	return nil
 }
 
-func setRequestContext(ctx context.Context, reqctx context.Context) context.Context {
+// SetRequestContext adds reqctx as a context value to ctx. This does not need to be called directly
+// and is exported for testing access.
+func SetRequestContext(ctx context.Context, reqctx context.Context) context.Context {
 	if reqctx == nil {
 		return ctx
 	}
@@ -294,7 +296,7 @@ func (handler *UnroutedHandler) Middleware(h http.Handler) http.Handler {
 // PostFile creates a new file upload using the datastore after validating the
 // length and parsing the metadata.
 func (handler *UnroutedHandler) PostFile(w http.ResponseWriter, r *http.Request) {
-	ctx := setRequestContext(context.Background(), r.Context())
+	ctx := SetRequestContext(context.Background(), r.Context())
 
 	// Check for presence of application/offset+octet-stream. If another content
 	// type is defined, it will be ignored and treated as none was set because
@@ -437,7 +439,7 @@ func (handler *UnroutedHandler) PostFile(w http.ResponseWriter, r *http.Request)
 
 // HeadFile returns the length and offset for the HEAD request
 func (handler *UnroutedHandler) HeadFile(w http.ResponseWriter, r *http.Request) {
-	ctx := setRequestContext(context.Background(), r.Context())
+	ctx := SetRequestContext(context.Background(), r.Context())
 
 	id, err := extractIDFromPath(r.URL.Path)
 	if err != nil {
@@ -501,7 +503,7 @@ func (handler *UnroutedHandler) HeadFile(w http.ResponseWriter, r *http.Request)
 // PatchFile adds a chunk to an upload. This operation is only allowed
 // if enough space in the upload is left.
 func (handler *UnroutedHandler) PatchFile(w http.ResponseWriter, r *http.Request) {
-	ctx := setRequestContext(context.Background(), r.Context())
+	ctx := SetRequestContext(context.Background(), r.Context())
 
 	// Check for presence of application/offset+octet-stream
 	if r.Header.Get("Content-Type") != "application/offset+octet-stream" {
@@ -716,7 +718,7 @@ func (handler *UnroutedHandler) finishUploadIfComplete(ctx context.Context, uplo
 // GetFile handles requests to download a file using a GET request. This is not
 // part of the specification.
 func (handler *UnroutedHandler) GetFile(w http.ResponseWriter, r *http.Request) {
-	ctx := setRequestContext(context.Background(), r.Context())
+	ctx := SetRequestContext(context.Background(), r.Context())
 
 	id, err := extractIDFromPath(r.URL.Path)
 	if err != nil {
@@ -837,7 +839,7 @@ func filterContentType(info FileInfo) (contentType string, contentDisposition st
 
 // DelFile terminates an upload permanently.
 func (handler *UnroutedHandler) DelFile(w http.ResponseWriter, r *http.Request) {
-	ctx := setRequestContext(context.Background(), r.Context())
+	ctx := SetRequestContext(context.Background(), r.Context())
 
 	// Abort the request handling if the required interface is not implemented
 	if !handler.composer.UsesTerminater {

--- a/pkg/handler/utils_test.go
+++ b/pkg/handler/utils_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -57,9 +58,10 @@ type httpTest struct {
 	ResHeader map[string]string
 }
 
-func (test *httpTest) Run(handler http.Handler, t *testing.T) *httptest.ResponseRecorder {
+func (test *httpTest) Run(ctx context.Context, handler http.Handler, t *testing.T) *httptest.ResponseRecorder {
 	req, _ := http.NewRequest(test.Method, test.URL, test.ReqBody)
 	req.RequestURI = test.URL
+	req = req.WithContext(ctx)
 
 	// Add headers
 	for key, value := range test.ReqHeader {


### PR DESCRIPTION
This pull request changes the http handlers to use the context provided in the request. This change is proposed so that the handlers are able to receive values set in the context in any upstream middleware.

I ran into this issue because we set an authorization value in the context, which I'm using downstream in a custom filestore. This doesn't work if the background context is used in the handlers, as the chain of context passed from above is broken.

Thanks!