### PR TITLE
Make use of gRPC metadatas to pass on Hook-Name.

### DIFF
--- a/cmd/tusd/cli/hooks/grpc.go
+++ b/cmd/tusd/cli/hooks/grpc.go
@@ -9,6 +9,7 @@ import (
 	pb "github.com/tus/tusd/pkg/proto/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/metadata"
 )
 
 type GrpcHook struct {
@@ -36,7 +37,8 @@ func (g *GrpcHook) Setup() error {
 }
 
 func (g *GrpcHook) InvokeHook(typ HookType, info handler.HookEvent, captureOutput bool) ([]byte, int, error) {
-	ctx := context.Background()
+	md := metadata.Pairs("Hook-Name", string(typ))
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	req := &pb.SendRequest{Hook: marshal(info)}
 	resp, err := g.Client.Send(ctx, req)
 	if err != nil {

--- a/cmd/tusd/cli/hooks/proto/v1/hook.proto
+++ b/cmd/tusd/cli/hooks/proto/v1/hook.proto
@@ -47,6 +47,8 @@ message Hook {
 	// HTTPRequest contains details about the HTTP request that reached
 	// tusd.
 	HTTPRequest httpRequest = 2;
+	// The hook name
+	string name = 3;
 }
 
 // Request data to send hook


### PR DESCRIPTION
Fixes #362 