### PR TITLE
docs: Headers are a list of values

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -27,7 +27,7 @@ A successful HTTP response code (i.e. smaller than `400`) indicates that tusd sh
 
 ### pre-create
 
-This event will be triggered before an upload is created, allowing you to run certain routines. For example, validating that specific metadata values are set, or verifying that a corresponding entity belonging to the upload (e.g. a user) exists. Because this event will result in a blocking hook, you can determine whether the upload should be created or rejected using the exit code. An exit code of `0` will allow the upload to be created and continued as usual. A non-zero exit code will reject an upload creation request, making it a good place for authentication and authorization. Please be aware, that during this stage the upload ID will be an empty string as the entity has not been created and therefore this piece of information is not yet available.
+This event will be triggered before an upload is created, allowing you to run certain routines. For example, validating that specific metadata values are set, or verifying that a corresponding entity belonging to the upload (e.g. a user) exists. Because this event will result in a blocking hook, you can determine whether the upload should be created or rejected using the exit code. An exit code of `0` will allow the upload to be created and continued as usual. A non-zero exit code will reject an upload creation request, making it a good place for authentication and authorization. Please be aware that during this stage the upload ID will be an empty string and `Storage` will be null. This is because the entity has not been created and therefore this piece of information is not yet available.
 
 ### post-create
 
@@ -114,8 +114,8 @@ The process of the hook files are provided with information about the event and 
     "URI": "/files/14b1c4c77771671a8479bc0444bbc5ce",
     "RemoteAddr": "1.2.3.4:47689",
     "Header": {
-      "Host": "myuploads.net",
-      "Cookies": "..."
+      "Host": ["myuploads.net"],
+      "Cookies": ["..."]
     }
   }
 }
@@ -187,8 +187,8 @@ Tusd will issue a `POST` request to the specified URL endpoint, specifying the h
     "URI": "/files/14b1c4c77771671a8479bc0444bbc5ce",
     "RemoteAddr": "1.2.3.4:47689",
     "Header": {
-      "Host": "myuploads.net",
-      "Cookies": "..."
+      "Host": ["myuploads.net"],
+      "Cookies": ["..."]
     }
   }
 }
@@ -263,6 +263,10 @@ Tusd will issue a `gRPC` request to the specified endpoint, specifying the hook 
     "Method": "PATCH",
     "URI": "/files/14b1c4c77771671a8479bc0444bbc5ce",
     "RemoteAddr": "1.2.3.4:47689",
+    "Header": {
+      "Host": ["myuploads.net"],
+      "Cookies": ["..."]
+    }
   }
 }
 ```

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -205,7 +205,7 @@ $ tusd --hooks-http http://localhost:8081/write --hooks-http-retry 5 --hooks-htt
 
 ## GRPC Hooks
 
-GRPC Hooks are the third type of hooks supported by tusd. Like the others hooks, it is disabled by default. To enable it, pass the `--hooks-grpc option to the tusd binary. The flag's value will be a gRPC endpoint, which the tusd binary will be sent to:
+GRPC Hooks are the third type of hooks supported by tusd. Like the others hooks, it is disabled by default. To enable it, pass the `--hooks-grpc` option to the tusd binary. The flag's value will be a gRPC endpoint, which the tusd binary will be sent to:
 
 ```bash
 $ tusd --hooks-grpc localhost:8080
@@ -262,11 +262,7 @@ Tusd will issue a `gRPC` request to the specified endpoint, specifying the hook 
   "HTTPRequest": {
     "Method": "PATCH",
     "URI": "/files/14b1c4c77771671a8479bc0444bbc5ce",
-    "RemoteAddr": "1.2.3.4:47689",
-    "Header": {
-      "Host": ["myuploads.net"],
-      "Cookies": ["..."]
-    }
+    "RemoteAddr": "1.2.3.4:47689"
   }
 }
 ```


### PR DESCRIPTION
Headers in Go are `map[string][]string` but the docs show them as being single values.
Also minor update to mention that `Storage` is null in the pre-create hook.