### PR TITLE
Rework Hook sending

### DIFF
--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -24,6 +24,8 @@ var Flags struct {
 	EnabledHooksString  string
 	FileHooksDir        string
 	HttpHooksEndpoint   string
+	SyncHooksString     string
+	SyncHooks           []hooks.HookType
 	HttpHooksRetry      int
 	HttpHooksBackoff    int
 	GrpcHooksEndpoint   string
@@ -55,6 +57,7 @@ func ParseFlags() {
 	flag.StringVar(&Flags.EnabledHooksString, "hooks-enabled-events", "", "Comma separated list of enabled hook events (e.g. post-create,post-finish). Leave empty to enable all events")
 	flag.StringVar(&Flags.FileHooksDir, "hooks-dir", "", "Directory to search for available hooks scripts")
 	flag.StringVar(&Flags.HttpHooksEndpoint, "hooks-http", "", "An HTTP endpoint to which hook events will be sent to")
+	flag.StringVar(&Flags.SyncHooksString, "hooks-synchronous-events", "pre-create", "Comma separated list of events which are executed synchronously")
 	flag.IntVar(&Flags.HttpHooksRetry, "hooks-http-retry", 3, "Number of times to retry on a 500 or network timeout")
 	flag.IntVar(&Flags.HttpHooksBackoff, "hooks-http-backoff", 1, "Number of seconds to wait before retrying each retry")
 	flag.StringVar(&Flags.GrpcHooksEndpoint, "hooks-grpc", "", "An gRPC endpoint to which hook events will be sent to")
@@ -70,6 +73,7 @@ func ParseFlags() {
 	flag.Parse()
 
 	SetEnabledHooks()
+	SetSyncHooks()
 
 	if Flags.FileHooksDir != "" {
 		Flags.FileHooksDir, _ = filepath.Abs(Flags.FileHooksDir)
@@ -93,5 +97,21 @@ func SetEnabledHooks() {
 
 	if len(Flags.EnabledHooks) == 0 {
 		Flags.EnabledHooks = hooks.AvailableHooks
+	}
+}
+
+func SetSyncHooks() {
+	if Flags.SyncHooksString != "" {
+		slc := strings.Split(Flags.SyncHooksString, ",")
+
+		for i, h := range slc {
+			slc[i] = strings.TrimSpace(h)
+
+			if !hookTypeInSlice(hooks.HookType(h), hooks.AvailableHooks) {
+				stderr.Fatalf("Unknown hook event type in -hooks-synchronous-events flag: %s", h)
+			}
+
+			Flags.SyncHooks = append(Flags.SyncHooks, hooks.HookType(h))
+		}
 	}
 }

--- a/cmd/tusd/cli/hooks.go
+++ b/cmd/tusd/cli/hooks.go
@@ -20,19 +20,39 @@ func hookTypeInSlice(a hooks.HookType, list []hooks.HookType) bool {
 	return false
 }
 
-func preCreateCallback(info handler.HookEvent) error {
-	if output, err := invokeHookSync(hooks.HookPreCreate, info, true); err != nil {
-		if hookErr, ok := err.(hooks.HookError); ok {
-			return hooks.NewHookError(
-				fmt.Errorf("pre-create hook failed: %s", err),
-				hookErr.StatusCode(),
-				hookErr.Body(),
-			)
+func hookCallback(typ hooks.HookType, info handler.HookEvent) error {
+	if hookTypeInSlice(typ, Flags.SyncHooks) {
+		if output, err := invokeHookSync(typ, info, true); err != nil {
+			if hookErr, ok := err.(hooks.HookError); ok {
+				return hooks.NewHookError(
+					fmt.Errorf("%s hook failed: %s", typ, err),
+					hookErr.StatusCode(),
+					hookErr.Body(),
+				)
+			}
+			return fmt.Errorf("%s hook failed: %s\n%s", typ, err, string(output))
 		}
-		return fmt.Errorf("pre-create hook failed: %s\n%s", err, string(output))
+	} else {
+		invokeHookAsync(typ, info)
 	}
 
 	return nil
+}
+
+func postFinishCallback(info handler.HookEvent) error {
+	return hookCallback(hooks.HookPostFinish, info)
+}
+func postTerminateCallback(info handler.HookEvent) error {
+	return hookCallback(hooks.HookPostTerminate, info)
+}
+func postReceiveCallback(info handler.HookEvent) error {
+	return hookCallback(hooks.HookPostReceive, info)
+}
+func postCreateCallback(info handler.HookEvent) error {
+	return hookCallback(hooks.HookPostCreate, info)
+}
+func preCreateCallback(info handler.HookEvent) error {
+	return hookCallback(hooks.HookPreCreate, info)
 }
 
 func SetupHookMetrics() {
@@ -81,32 +101,25 @@ func SetupPreHooks(config *handler.Config) error {
 		enabledHooksString = append(enabledHooksString, string(h))
 	}
 
+	var syncHooksString []string
+	for _, h := range Flags.SyncHooks {
+		syncHooksString = append(syncHooksString, string(h))
+	}
+
 	stdout.Printf("Enabled hook events: %s", strings.Join(enabledHooksString, ", "))
+	stdout.Printf("Synchronous hook events: %s", strings.Join(syncHooksString, ", "))
 
 	if err := hookHandler.Setup(); err != nil {
 		return err
 	}
 
-	config.PreUploadCreateCallback = preCreateCallback
+	config.PostFinishCallback = postFinishCallback
+	config.PostTerminateCallback = postTerminateCallback
+	config.PostReceiveCallback = postReceiveCallback
+	config.PostCreateCallback = postCreateCallback
+	config.PreCreateCallback = preCreateCallback
 
 	return nil
-}
-
-func SetupPostHooks(handler *handler.Handler) {
-	go func() {
-		for {
-			select {
-			case info := <-handler.CompleteUploads:
-				invokeHookAsync(hooks.HookPostFinish, info)
-			case info := <-handler.TerminatedUploads:
-				invokeHookAsync(hooks.HookPostTerminate, info)
-			case info := <-handler.UploadProgress:
-				invokeHookAsync(hooks.HookPostReceive, info)
-			case info := <-handler.CreatedUploads:
-				invokeHookAsync(hooks.HookPostCreate, info)
-			}
-		}
-	}()
 }
 
 func invokeHookAsync(typ hooks.HookType, info handler.HookEvent) {

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -21,10 +21,10 @@ func Serve() {
 		BasePath:                Flags.Basepath,
 		RespectForwardedHeaders: Flags.BehindProxy,
 		StoreComposer:           Composer,
-		NotifyCompleteUploads:   true,
-		NotifyTerminatedUploads: true,
-		NotifyUploadProgress:    true,
-		NotifyCreatedUploads:    true,
+		NotifyCompleteUploads:   false,
+		NotifyTerminatedUploads: false,
+		NotifyUploadProgress:    false,
+		NotifyCreatedUploads:    false,
 	}
 
 	if err := SetupPreHooks(&config); err != nil {
@@ -48,8 +48,6 @@ func Serve() {
 	}
 
 	stdout.Printf("Using %s as the base path.\n", basepath)
-
-	SetupPostHooks(handler)
 
 	if Flags.ExposeMetrics {
 		SetupMetrics(handler)

--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -40,11 +40,17 @@ type Config struct {
 	// potentially set by proxies when generating an absolute URL in the
 	// response to POST requests.
 	RespectForwardedHeaders bool
-	// PreUploadreateCCallback will be invoked before a new upload is created, if the
-	// property is supplied. If the callback returns nil, the upload will be created.
+
+	// Callbacks will be invoked if the property is supplied.
+	PostFinishCallback    func(hook HookEvent) error
+	PostTerminateCallback func(hook HookEvent) error
+	PostReceiveCallback   func(hook HookEvent) error
+	PostCreateCallback    func(hook HookEvent) error
+	// For the PreCreate callback only
+	// If the callback returns nil, the upload will be created.
 	// Otherwise the HTTP request will be aborted. This can be used to implement
 	// validation of upload metadata etc.
-	PreUploadCreateCallback func(hook HookEvent) error
+	PreCreateCallback func(hook HookEvent) error
 }
 
 func (config *Config) validate() error {


### PR DESCRIPTION
Change the tusd standalone cli to use callback functions to issue hooks, rather than channels, for all events.
Previously only `pre-create` used a callback function which allowed it to be blocking.

Now all events trigger a callback and can be optionally configured as synchronous / blocking. (Fixes #350)

The event channels are left in place for anyone using tusd programatically but the standalone cli disables them.
