### PR TITLE
Allow empty metadata values

### DIFF
--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -1120,19 +1120,27 @@ func ParseMetadataHeader(header string) map[string]string {
 
 		parts := strings.Split(element, " ")
 
-		// Do not continue with this element if no key and value or presented
-		if len(parts) != 2 {
+		if len(parts) > 2 {
 			continue
 		}
 
-		// Ignore corrent element if the value is no valid base64
 		key := parts[0]
-		value, err := base64.StdEncoding.DecodeString(parts[1])
-		if err != nil {
+		if key == "" {
 			continue
 		}
 
-		meta[key] = string(value)
+		value := ""
+		if len(parts) == 2 {
+			// Ignore current element if the value is no valid base64
+			dec, err := base64.StdEncoding.DecodeString(parts[1])
+			if err != nil {
+				continue
+			}
+
+			value = string(dec)
+		}
+
+		meta[key] = value
 	}
 
 	return meta

--- a/pkg/handler/unrouted_handler_test.go
+++ b/pkg/handler/unrouted_handler_test.go
@@ -1,0 +1,35 @@
+package handler_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/tus/tusd/pkg/handler"
+)
+
+func TestParseMetadataHeader(t *testing.T) {
+	a := assert.New(t)
+
+	md := ParseMetadataHeader("")
+	a.Equal(md, map[string]string{})
+
+	// Invalidly encoded values are ignored
+	md = ParseMetadataHeader("k1 INVALID")
+	a.Equal(md, map[string]string{})
+
+	// If the same key occurs multiple times, the last one wins
+	md = ParseMetadataHeader("k1 aGVsbG8=,k1 d29ybGQ=")
+	a.Equal(md, map[string]string{
+		"k1": "world",
+	})
+
+	// Empty values are mapped to an empty string
+	md = ParseMetadataHeader("k1 aGVsbG8=, k2, k3 , k4 d29ybGQ=")
+	a.Equal(md, map[string]string{
+		"k1": "hello",
+		"k2": "",
+		"k3": "",
+		"k4": "world",
+	})
+}


### PR DESCRIPTION
Allow empty metadata values to be stored and returned by tusd.

Fixes #397