### PR TITLE
S3Store: Concurrently write upload parts to S3 while reading from client

### DIFF
--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -57,7 +57,7 @@ server {
         proxy_http_version       1.1;
 
         # Add X-Forwarded-* headers
-        proxy_set_header X-Forwarded-Host $hostname;
+        proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
 
         proxy_set_header         Upgrade $http_upgrade;

--- a/pkg/handler/head_test.go
+++ b/pkg/handler/head_test.go
@@ -26,8 +26,8 @@ func TestHead(t *testing.T) {
 				Offset: 11,
 				Size:   44,
 				MetaData: map[string]string{
-					"name": "lunrjs.png",
-					"type": "image/png",
+					"name":  "lunrjs.png",
+					"empty": "",
 				},
 			}, nil),
 			lock.EXPECT().Unlock().Return(nil),
@@ -57,8 +57,8 @@ func TestHead(t *testing.T) {
 
 		// Since the order of a map is not guaranteed in Go, we need to be prepared
 		// for the case, that the order of the metadata may have been changed
-		if v := res.Header().Get("Upload-Metadata"); v != "name bHVucmpzLnBuZw==,type aW1hZ2UvcG5n" &&
-			v != "type aW1hZ2UvcG5n,name bHVucmpzLnBuZw==" {
+		if v := res.Header().Get("Upload-Metadata"); v != "name bHVucmpzLnBuZw==,empty " &&
+			v != "empty ,name bHVucmpzLnBuZw==" {
 			t.Errorf("Expected valid metadata (got '%s')", v)
 		}
 	})

--- a/pkg/handler/post_test.go
+++ b/pkg/handler/post_test.go
@@ -23,16 +23,18 @@ func TestPost(t *testing.T) {
 			store.EXPECT().NewUpload(context.Background(), FileInfo{
 				Size: 300,
 				MetaData: map[string]string{
-					"foo": "hello",
-					"bar": "world",
+					"foo":   "hello",
+					"bar":   "world",
+					"empty": "",
 				},
 			}).Return(upload, nil),
 			upload.EXPECT().GetInfo(context.Background()).Return(FileInfo{
 				ID:   "foo",
 				Size: 300,
 				MetaData: map[string]string{
-					"foo": "hello",
-					"bar": "world",
+					"foo":   "hello",
+					"bar":   "world",
+					"empty": "",
 				},
 			}, nil),
 		)
@@ -52,7 +54,7 @@ func TestPost(t *testing.T) {
 				"Tus-Resumable": "1.0.0",
 				"Upload-Length": "300",
 				// Invalid Base64-encoded values should be ignored
-				"Upload-Metadata": "foo aGVsbG8=, bar d29ybGQ=, hah INVALID",
+				"Upload-Metadata": "foo aGVsbG8=, bar d29ybGQ=, hah INVALID, empty",
 			},
 			Code: http.StatusCreated,
 			ResHeader: map[string]string{

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -1120,19 +1120,27 @@ func ParseMetadataHeader(header string) map[string]string {
 
 		parts := strings.Split(element, " ")
 
-		// Do not continue with this element if no key and value or presented
-		if len(parts) != 2 {
+		if len(parts) > 2 {
 			continue
 		}
 
-		// Ignore corrent element if the value is no valid base64
 		key := parts[0]
-		value, err := base64.StdEncoding.DecodeString(parts[1])
-		if err != nil {
+		if key == "" {
 			continue
 		}
 
-		meta[key] = string(value)
+		value := ""
+		if len(parts) == 2 {
+			// Ignore current element if the value is no valid base64
+			dec, err := base64.StdEncoding.DecodeString(parts[1])
+			if err != nil {
+				continue
+			}
+
+			value = string(dec)
+		}
+
+		meta[key] = value
 	}
 
 	return meta

--- a/pkg/handler/unrouted_handler_test.go
+++ b/pkg/handler/unrouted_handler_test.go
@@ -1,0 +1,35 @@
+package handler_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/tus/tusd/pkg/handler"
+)
+
+func TestParseMetadataHeader(t *testing.T) {
+	a := assert.New(t)
+
+	md := ParseMetadataHeader("")
+	a.Equal(md, map[string]string{})
+
+	// Invalidly encoded values are ignored
+	md = ParseMetadataHeader("k1 INVALID")
+	a.Equal(md, map[string]string{})
+
+	// If the same key occurs multiple times, the last one wins
+	md = ParseMetadataHeader("k1 aGVsbG8=,k1 d29ybGQ=")
+	a.Equal(md, map[string]string{
+		"k1": "world",
+	})
+
+	// Empty values are mapped to an empty string
+	md = ParseMetadataHeader("k1 aGVsbG8=, k2, k3 , k4 d29ybGQ=")
+	a.Equal(md, map[string]string{
+		"k1": "hello",
+		"k2": "",
+		"k3": "",
+		"k4": "world",
+	})
+}

--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -135,6 +135,11 @@ type S3Store struct {
 	// MaxObjectSize is the maximum size an S3 Object can have according to S3
 	// API specifications. See link above.
 	MaxObjectSize int64
+	// MaxBufferedParts is the number of additional parts that can be received from
+	// the client and stored on disk while a part is being uploaded to S3. This
+	// can help improve throughput by not blocking the client while tusd is
+	// communicating with the S3 API, which can have unpredictable latency.
+	MaxBufferedParts int64
 }
 
 type S3API interface {
@@ -159,6 +164,7 @@ func New(bucket string, service S3API) S3Store {
 		MinPartSize:       5 * 1024 * 1024,
 		MaxMultipartParts: 10000,
 		MaxObjectSize:     5 * 1024 * 1024 * 1024 * 1024,
+		MaxBufferedParts:  20,
 	}
 }
 
@@ -272,6 +278,73 @@ func (upload *s3Upload) writeInfo(ctx context.Context, info handler.FileInfo) er
 	return err
 }
 
+// s3PartProducer converts a stream of bytes from the reader into a stream of files on disk
+type s3PartProducer struct {
+	files chan<- *os.File
+	done  chan struct{}
+	err   error
+	r     io.Reader
+}
+
+func (spp *s3PartProducer) produce(partSize int64) {
+	for {
+		file, err := spp.nextPart(partSize)
+		if err != nil {
+			spp.err = err
+			close(spp.files)
+			return
+		}
+		if file == nil {
+			close(spp.files)
+			return
+		}
+		select {
+		case spp.files <- file:
+		case <-spp.done:
+			close(spp.files)
+			return
+		}
+	}
+}
+
+func (spp *s3PartProducer) nextPart(size int64) (*os.File, error) {
+	// Create a temporary file to store the part
+	file, err := ioutil.TempFile("", "tusd-s3-tmp-")
+	if err != nil {
+		return nil, err
+	}
+
+	limitedReader := io.LimitReader(spp.r, size)
+	n, err := io.Copy(file, limitedReader)
+
+	// If the HTTP PATCH request gets interrupted in the middle (e.g. because
+	// the user wants to pause the upload), Go's net/http returns an io.ErrUnexpectedEOF.
+	// However, for S3Store it's not important whether the stream has ended
+	// on purpose or accidentally. Therefore, we ignore this error to not
+	// prevent the remaining chunk to be stored on S3.
+	if err == io.ErrUnexpectedEOF {
+		err = nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// If the entire request body is read and no more data is available,
+	// io.Copy returns 0 since it is unable to read any bytes. In that
+	// case, we can close the s3PartProducer.
+	if n == 0 {
+		os.Remove(file.Name())
+		file.Close()
+		return nil, nil
+	}
+
+	// Seek to the beginning of the file
+	file.Seek(0, 0)
+
+	return file, nil
+}
+
 func (upload s3Upload) WriteChunk(ctx context.Context, offset int64, src io.Reader) (int64, error) {
 	id := upload.id
 	store := upload.store
@@ -315,49 +388,43 @@ func (upload s3Upload) WriteChunk(ctx context.Context, offset int64, src io.Read
 		src = io.MultiReader(incompletePartFile, src)
 	}
 
-	for {
-		// Create a temporary file to store the part in it
-		file, err := ioutil.TempFile("", "tusd-s3-tmp-")
+	fileChan := make(chan *os.File, store.MaxBufferedParts)
+	doneChan := make(chan struct{})
+	defer close(doneChan)
+
+	// If we panic or return while there are still files in the channel, then
+	// we may leak file descriptors. Let's ensure that those are cleaned up.
+	defer func() {
+		for file := range fileChan {
+			os.Remove(file.Name())
+			file.Close()
+		}
+	}()
+
+	partProducer := s3PartProducer{
+		done:  doneChan,
+		files: fileChan,
+		r:     src,
+	}
+	go partProducer.produce(optimalPartSize)
+
+	for file := range fileChan {
+		stat, err := file.Stat()
 		if err != nil {
-			return bytesUploaded, err
+			return 0, err
 		}
-		defer os.Remove(file.Name())
-		defer file.Close()
-
-		limitedReader := io.LimitReader(src, optimalPartSize)
-		n, err := io.Copy(file, limitedReader)
-
-		// If the HTTP PATCH request gets interrupted in the middle (e.g. because
-		// the user wants to pause the upload), Go's net/http returns an io.ErrUnexpectedEOF.
-		// However, for S3Store it's not important whether the stream has ended
-		// on purpose or accidentally. Therefore, we ignore this error to not
-		// prevent the remaining chunk to be stored on S3.
-		if err == io.ErrUnexpectedEOF {
-			err = nil
-		}
-
-		// io.Copy does not return io.EOF, so we not have to handle it differently.
-		if err != nil {
-			return bytesUploaded, err
-		}
-		// If io.Copy is finished reading, it will always return (0, nil).
-		if n == 0 {
-			return (bytesUploaded - incompletePartSize), nil
-		}
-
-		// Seek to the beginning of the file
-		file.Seek(0, 0)
+		n := stat.Size()
 
 		isFinalChunk := !info.SizeIsDeferred && (size == (offset-incompletePartSize)+n)
 		if n >= store.MinPartSize || isFinalChunk {
-			_, err = store.Service.UploadPartWithContext(ctx, &s3.UploadPartInput{
+			uploadPartInput := &s3.UploadPartInput{
 				Bucket:     aws.String(store.Bucket),
 				Key:        store.keyWithPrefix(uploadId),
 				UploadId:   aws.String(multipartId),
 				PartNumber: aws.Int64(nextPartNum),
 				Body:       file,
-			})
-			if err != nil {
+			}
+			if err := upload.putPartForUpload(ctx, uploadPartInput, file); err != nil {
 				return bytesUploaded, err
 			}
 		} else {
@@ -374,6 +441,16 @@ func (upload s3Upload) WriteChunk(ctx context.Context, offset int64, src io.Read
 		bytesUploaded += n
 		nextPartNum += 1
 	}
+
+	return bytesUploaded - incompletePartSize, partProducer.err
+}
+
+func (upload *s3Upload) putPartForUpload(ctx context.Context, uploadPartInput *s3.UploadPartInput, file *os.File) error {
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	_, err := upload.store.Service.UploadPartWithContext(ctx, uploadPartInput)
+	return err
 }
 
 func (upload *s3Upload) GetInfo(ctx context.Context) (info handler.FileInfo, err error) {
@@ -824,11 +901,14 @@ func (store S3Store) getIncompletePartForUpload(ctx context.Context, uploadId st
 	return obj, err
 }
 
-func (store S3Store) putIncompletePartForUpload(ctx context.Context, uploadId string, r io.ReadSeeker) error {
+func (store S3Store) putIncompletePartForUpload(ctx context.Context, uploadId string, file *os.File) error {
+	defer os.Remove(file.Name())
+	defer file.Close()
+
 	_, err := store.Service.PutObjectWithContext(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(store.Bucket),
 		Key:    store.metadataKeyWithPrefix(uploadId + ".part"),
-		Body:   r,
+		Body:   file,
 	})
 	return err
 }

--- a/pkg/s3store/s3store_part_producer_test.go
+++ b/pkg/s3store/s3store_part_producer_test.go
@@ -27,6 +27,7 @@ func TestPartProducerConsumesEntireReaderWithoutError(t *testing.T) {
 	expectedStr := "test"
 	r := strings.NewReader(expectedStr)
 	pp := s3PartProducer{
+		store: &S3Store{},
 		done:  doneChan,
 		files: fileChan,
 		r:     r,
@@ -62,6 +63,7 @@ func TestPartProducerExitsWhenDoneChannelIsClosed(t *testing.T) {
 	fileChan := make(chan *os.File)
 	doneChan := make(chan struct{})
 	pp := s3PartProducer{
+		store: &S3Store{},
 		done:  doneChan,
 		files: fileChan,
 		r:     InfiniteZeroReader{},
@@ -89,6 +91,7 @@ func TestPartProducerExitsWhenDoneChannelIsClosedBeforeAnyPartIsSent(t *testing.
 	fileChan := make(chan *os.File)
 	doneChan := make(chan struct{})
 	pp := s3PartProducer{
+		store: &S3Store{},
 		done:  doneChan,
 		files: fileChan,
 		r:     InfiniteZeroReader{},
@@ -116,6 +119,7 @@ func TestPartProducerExitsWhenUnableToReadFromFile(t *testing.T) {
 	fileChan := make(chan *os.File)
 	doneChan := make(chan struct{})
 	pp := s3PartProducer{
+		store: &S3Store{},
 		done:  doneChan,
 		files: fileChan,
 		r:     ErrorReader{},

--- a/pkg/s3store/s3store_part_producer_test.go
+++ b/pkg/s3store/s3store_part_producer_test.go
@@ -1,0 +1,155 @@
+package s3store
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+type InfiniteZeroReader struct{}
+
+func (izr InfiniteZeroReader) Read(b []byte) (int, error) {
+	b[0] = 0
+	return 1, nil
+}
+
+type ErrorReader struct{}
+
+func (ErrorReader) Read(b []byte) (int, error) {
+	return 0, errors.New("error from ErrorReader")
+}
+
+func TestPartProducerConsumesEntireReaderWithoutError(t *testing.T) {
+	fileChan := make(chan *os.File)
+	doneChan := make(chan struct{})
+	expectedStr := "test"
+	r := strings.NewReader(expectedStr)
+	pp := s3PartProducer{
+		done:  doneChan,
+		files: fileChan,
+		r:     r,
+	}
+	go pp.produce(1)
+
+	actualStr := ""
+	b := make([]byte, 1)
+	for f := range fileChan {
+		n, err := f.Read(b)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if n != 1 {
+			t.Fatalf("incorrect number of bytes read: wanted %d, got %d", 1, n)
+		}
+		actualStr += string(b)
+
+		os.Remove(f.Name())
+		f.Close()
+	}
+
+	if actualStr != expectedStr {
+		t.Errorf("incorrect string read from channel: wanted %s, got %s", expectedStr, actualStr)
+	}
+
+	if pp.err != nil {
+		t.Errorf("unexpected error from part producer: %s", pp.err)
+	}
+}
+
+func TestPartProducerExitsWhenDoneChannelIsClosed(t *testing.T) {
+	fileChan := make(chan *os.File)
+	doneChan := make(chan struct{})
+	pp := s3PartProducer{
+		done:  doneChan,
+		files: fileChan,
+		r:     InfiniteZeroReader{},
+	}
+
+	completedChan := make(chan struct{})
+	go func() {
+		pp.produce(10)
+		completedChan <- struct{}{}
+	}()
+
+	close(doneChan)
+
+	select {
+	case <-completedChan:
+		// producer exited cleanly
+	case <-time.After(2 * time.Second):
+		t.Error("timed out waiting for producer to exit")
+	}
+
+	safelyDrainChannelOrFail(fileChan, t)
+}
+
+func TestPartProducerExitsWhenDoneChannelIsClosedBeforeAnyPartIsSent(t *testing.T) {
+	fileChan := make(chan *os.File)
+	doneChan := make(chan struct{})
+	pp := s3PartProducer{
+		done:  doneChan,
+		files: fileChan,
+		r:     InfiniteZeroReader{},
+	}
+
+	close(doneChan)
+
+	completedChan := make(chan struct{})
+	go func() {
+		pp.produce(10)
+		completedChan <- struct{}{}
+	}()
+
+	select {
+	case <-completedChan:
+		// producer exited cleanly
+	case <-time.After(2 * time.Second):
+		t.Error("timed out waiting for producer to exit")
+	}
+
+	safelyDrainChannelOrFail(fileChan, t)
+}
+
+func TestPartProducerExitsWhenUnableToReadFromFile(t *testing.T) {
+	fileChan := make(chan *os.File)
+	doneChan := make(chan struct{})
+	pp := s3PartProducer{
+		done:  doneChan,
+		files: fileChan,
+		r:     ErrorReader{},
+	}
+
+	completedChan := make(chan struct{})
+	go func() {
+		pp.produce(10)
+		completedChan <- struct{}{}
+	}()
+
+	select {
+	case <-completedChan:
+		// producer exited cleanly
+	case <-time.After(2 * time.Second):
+		t.Error("timed out waiting for producer to exit")
+	}
+
+	safelyDrainChannelOrFail(fileChan, t)
+
+	if pp.err == nil {
+		t.Error("expected an error but didn't get one")
+	}
+}
+
+func safelyDrainChannelOrFail(c chan *os.File, t *testing.T) {
+	// At this point, we've signaled that the producer should exit, but it may write a few files
+	// into the channel before closing it and exiting. Make sure that we get a nil value
+	// eventually.
+	for i := 0; i < 100; i++ {
+		if f := <-c; f == nil {
+			return
+		}
+	}
+
+	t.Fatal("timed out waiting for channel to drain")
+}


### PR DESCRIPTION
## Overview

As discussed in #379, the throughput performance of S3Store can degrade when the S3 (or compatible) API has high or unpredictable latency. Currently, S3Store synchronously reads bytes from the client, writes them to disk, and then writes the file on disk to the S3 API. That approach is simple and reliable, but it blocks the client from transmitting any new bytes while tusd is writing the current part to S3. This blocking causes the client to transmit more slowly due to standard TCP behavior.

This PR introduces `s3ChunkProducer`, a struct that is responsible for consuming bytes from the source reader (connected to the client) and converting them into `*os.File` instances that are pushed into a channel. The original request goroutine then consumes files from this channel until it's empty (or there's an error), uploading each file as a new part in S3.

Decoupling reading client bytes from writing them into S3 means that the two processes happen in parallel, which should allow the client to upload at a consistent speed even if the S3 API is intermittently slow. Actual performance will depend on details of the deployment, e.g. whether the tusd server is near its S3 endpoint on the network, the available bandwidth between them, how much bandwidth the client has along the path to tusd, etc. I've introduced a `MaxBufferedParts` field on S3Store to allow the server to store multiple complete parts on disk before they're written into S3. If the client is able to upload to the tusd server faster than tusd can upload to S3, then a larger buffer size may be a good way to boost client upload performance.

## Notes

Introducing parallelism in the `WriteChunk` workflow means that many of the S3Store tests run nondeterministically when uploading parts. To help with this, the first commit in this branch relaxes the use of `gomock.InOrder` so that we don't require a strict ordering of function calls -- but we still require each individual call to happen at some point. I tried to keep the strict ordering in places where it mattered. I'm not an expert on gomock, so please let me know if there's a better way to do this.

The consumer will drain the files channel and write all available parts into S3, even if the client has gone away. I think this is mostly a good thing, but it may be possible for a high-throughput client to upload several parts into the buffer and then get disconnected because of a network issue. If the server isn't using a locker and the client tries to resume uploading while tusd is still uploading those buffered parts, then we may run into a conflict. I think this is already a possibility on tusd master, but the part buffer could make such a scenario more likely.

To help tusd operators tune the size of the file channel buffer, I'd like to add a metric for how much time we spend blocking the client. Maybe this could be measured in the main WriteChunk for loop and reported at the end of an upload. I'm not sure how to pass the time data from the S3Store (which knows about part upload latency) back to the handler (which owns the Metrics struct), though. Open to suggestions.

This code has not received any production testing yet, so I would consider it unsafe until we're confident that the test coverage is sufficient and that there are no logic errors.