### PR TITLE
graceful shutdown - preliminary attempt 

### DIFF
--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -40,6 +40,7 @@ var Flags struct {
 	BehindProxy             bool
 	VerboseOutput           bool
 	S3TransferAcceleration  bool
+	ShutdownTimeout         int
 }
 
 func ParseFlags() {
@@ -73,6 +74,7 @@ func ParseFlags() {
 	flag.BoolVar(&Flags.BehindProxy, "behind-proxy", false, "Respect X-Forwarded-* and similar headers which may be set by proxies")
 	flag.BoolVar(&Flags.VerboseOutput, "verbose", true, "Enable verbose logging output")
 	flag.BoolVar(&Flags.S3TransferAcceleration, "s3-transfer-acceleration", false, "Use AWS S3 transfer acceleration endpoint (requires -s3-bucket option and Transfer Acceleration property on S3 bucket to be set)")
+	flag.IntVar(&Flags.ShutdownTimeout, "shutdown-timeout", 30, "Number of seconds before failing a graceful shutdown")
 	flag.Parse()
 
 	SetEnabledHooks()

--- a/cmd/tusd/cli/metrics.go
+++ b/cmd/tusd/cli/metrics.go
@@ -23,11 +23,11 @@ var MetricsHookErrorsTotal = prometheus.NewCounterVec(
 	[]string{"hooktype"},
 )
 
-func SetupMetrics(handler *handler.Handler) {
+func SetupMetrics(mux * http.ServeMux, handler *handler.Handler) {
 	prometheus.MustRegister(MetricsOpenConnections)
 	prometheus.MustRegister(MetricsHookErrorsTotal)
 	prometheus.MustRegister(prometheuscollector.New(handler.Metrics))
 
 	stdout.Printf("Using %s as the metrics path.\n", Flags.MetricsPath)
-	http.Handle(Flags.MetricsPath, promhttp.Handler())
+	mux.Handle(Flags.MetricsPath, promhttp.Handler())
 }

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -117,7 +117,6 @@ func Serve() {
 		}
 		return nil
 	}, func(error) {
-		// TODO(rbastic): externalize shutdown timeout? for now just 30 mins? i don't know.
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(Flags.ShutdownTimeout))
 		defer cancel()
 		stderr.Printf("httpserver shutting down %s\n", s.Shutdown(ctx))

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -118,9 +118,9 @@ func Serve() {
 		return nil
 	}, func(error) {
 		// TODO(rbastic): externalize shutdown timeout? for now just 30 mins? i don't know.
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*600)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(Flags.ShutdownTimeout))
 		defer cancel()
-		stderr.Fatalf("httpserver shutting down %s", s.Shutdown(ctx))
+		stderr.Printf("httpserver shutting down %s\n", s.Shutdown(ctx))
 	})
 
 	cancel := make(chan struct{})

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -63,11 +63,6 @@ func Serve() {
 	s := &http.Server{
 		Addr:		address,
 		Handler:        mux,
-		// TODO(rbastic): what to do about these?
-		// ReadTimeout:    5000 * time.Second,
-		// WriteTimeout:   5000 * time.Second,
-		// MaxHeaderBytes: 1 << 20,
-		// END TODO(rbastic)
 	}
 
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.5
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
+	github.com/oklog/run v1.1.0
 	github.com/prometheus/client_golang v1.0.0
 	github.com/sethgrid/pester v0.0.0-20190127155807-68a33a018ad0
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
+github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
+github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
As requested, here is my PR to resolve https://github.com/tus/tusd/issues/395

I tested this last night and the behavior is as follows:
- when uploading, the server waits until the active handler being executed is complete (so a chunk can be written) before shutting down
- if tusd is then started back up (and I resume the upload) it picks back up where it left off

In my testing, I killed tusd with an active upload at 34%, started tusd back up, and it picked right back up at 35% like nothing had happened. Then it completed successfully. This was just a small test but exactly the behavior desired/expected, I think? 

Main questions: what do you think about the TODO markers? The shutdown timeout, etc.? I'm guessing these should become CLI flags.