### PR TITLE
Fix unrouted handler forwarded header

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,7 @@ github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=

--- a/pkg/handler/post_test.go
+++ b/pkg/handler/post_test.go
@@ -310,11 +310,11 @@ func TestPost(t *testing.T) {
 					"Upload-Length":     "300",
 					"X-Forwarded-Host":  "bar.com",
 					"X-Forwarded-Proto": "http",
-					"Forwarded":         "proto=https,host=foo.com",
+					"Forwarded":         "for=192.168.10.112;host=upload.example.tld;proto=https;proto-version=",
 				},
 				Code: http.StatusCreated,
 				ResHeader: map[string]string{
-					"Location": "https://foo.com/files/foo",
+					"Location": "https://upload.example.tld/files/foo",
 				},
 			}).Run(handler, t)
 		})

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -21,7 +21,7 @@ const UploadLengthDeferred = "1"
 
 var (
 	reExtractFileID  = regexp.MustCompile(`([^/]+)\/?$`)
-	reForwardedHost  = regexp.MustCompile(`host=([^,]+)`)
+	reForwardedHost  = regexp.MustCompile(`host=([^;]+)`)
 	reForwardedProto = regexp.MustCompile(`proto=(https?)`)
 	reMimeType       = regexp.MustCompile(`^[a-z]+\/[a-z0-9\-\+\.]+$`)
 )

--- a/pkg/handler/unrouted_handler_test.go
+++ b/pkg/handler/unrouted_handler_test.go
@@ -1,6 +1,8 @@
 package handler_test
 
 import (
+	"net/http"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,4 +34,97 @@ func TestParseMetadataHeader(t *testing.T) {
 		"k3": "",
 		"k4": "world",
 	})
+}
+
+// no harm to copy some lines :D
+var (
+	reOriginalForwardedHost = regexp.MustCompile(`host=([^,]+)`) // unrouted_handler.go:24
+	reModifiedForwardedHost = regexp.MustCompile(`host=([^;]+)`)
+	reForwardedProto        = regexp.MustCompile(`proto=(https?)`)
+)
+
+const (
+	hostToCheck  = "upload.example.tld"
+	protoToCheck = "https"
+)
+
+func TestGetHostAndProto(t *testing.T) {
+
+	a := assert.New(t)
+	r, err := newRequest()
+	if err != nil {
+		t.Errorf("Error constructing test request : %v", err)
+	}
+
+	host, proto := getHostAndProtocol(r, true, false)
+	a.Equal(hostToCheck, host)
+	a.Equal(protoToCheck, proto)
+
+}
+
+func TestOriginalHostAndProto(t *testing.T) {
+	a := assert.New(t)
+	r, err := newRequest()
+	if err != nil {
+		t.Errorf("Error constructing test request : %v", err)
+	}
+
+	host, proto := getHostAndProtocol(r, true, true)
+	a.Equal(hostToCheck, host)
+	a.Equal(protoToCheck, proto)
+}
+
+// newRequest creates new test/dummy request
+func newRequest() (*http.Request, error) {
+	request, err := http.NewRequest(http.MethodGet, "https://upload.example.tld/files/", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	request.Header.Set("X-Forwarded-Host", hostToCheck)
+	request.Header.Set("X-Forwarded-Proto", protoToCheck)
+	request.Header.Set("Forwarded", "for=192.168.10.112;host=upload.example.tld;proto=https;proto-version=")
+	return request, nil
+}
+
+func getHostAndProtocol(r *http.Request, allowForwarded bool, shouldFail bool) (host, proto string) {
+	if r.TLS != nil {
+		proto = "https"
+	} else {
+		proto = "http"
+	}
+
+	host = r.Host
+
+	if !allowForwarded {
+		return
+	}
+
+	if h := r.Header.Get("X-Forwarded-Host"); h != "" {
+		host = h
+	}
+
+	if h := r.Header.Get("X-Forwarded-Proto"); h == "http" || h == "https" {
+		proto = h
+	}
+
+	if h := r.Header.Get("Forwarded"); h != "" {
+		var hosts []string
+		switch shouldFail {
+		case true:
+			hosts = reOriginalForwardedHost.FindStringSubmatch(h)
+		default:
+			hosts = reModifiedForwardedHost.FindStringSubmatch(h)
+		}
+
+		if len(hosts) == 2 {
+			host = hosts[1]
+		}
+
+		if r := reForwardedProto.FindStringSubmatch(h); len(r) == 2 {
+			proto = r[1]
+		}
+	}
+
+	return
 }

--- a/pkg/handler/unrouted_handler_test.go
+++ b/pkg/handler/unrouted_handler_test.go
@@ -70,8 +70,9 @@ func TestOriginalHostAndProto(t *testing.T) {
 	}
 
 	host, proto := getHostAndProtocol(r, true, true)
-	a.Equal(hostToCheck, host)
+	// a.Equal(hostToCheck, host)
 	a.Equal(protoToCheck, proto)
+	a.NotEqual(hostToCheck, host)
 }
 
 // newRequest creates new test/dummy request

--- a/pkg/handler/unrouted_handler_test.go
+++ b/pkg/handler/unrouted_handler_test.go
@@ -1,8 +1,6 @@
 package handler_test
 
 import (
-	"net/http"
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,76 +32,4 @@ func TestParseMetadataHeader(t *testing.T) {
 		"k3": "",
 		"k4": "world",
 	})
-}
-
-// no harm to copy some lines :D
-var (
-	reForwardedHost  = regexp.MustCompile(`host=([^;]+)`) // unrouted_handler.go:24
-	reForwardedProto = regexp.MustCompile(`proto=(https?)`)
-)
-
-const (
-	hostToCheck  = "upload.example.tld"
-	protoToCheck = "https"
-)
-
-func TestGetHostAndProto(t *testing.T) {
-
-	a := assert.New(t)
-	r, err := newRequest()
-	if err != nil {
-		t.Errorf("Error constructing test request : %v", err)
-	}
-
-	host, proto := getHostAndProtocol(r, true)
-	a.Equal(hostToCheck, host)
-	a.Equal(protoToCheck, proto)
-
-}
-
-// newRequest creates new test/dummy request
-func newRequest() (*http.Request, error) {
-	request, err := http.NewRequest(http.MethodGet, "https://upload.example.tld/files/", nil)
-	if err != nil {
-		return nil, err
-	}
-
-	request.Header.Set("X-Forwarded-Host", hostToCheck)
-	request.Header.Set("X-Forwarded-Proto", protoToCheck)
-	request.Header.Set("Forwarded", "for=192.168.10.112;host=upload.example.tld;proto=https;proto-version=")
-	return request, nil
-}
-
-func getHostAndProtocol(r *http.Request, allowForwarded bool) (host, proto string) {
-	if r.TLS != nil {
-		proto = "https"
-	} else {
-		proto = "http"
-	}
-
-	host = r.Host
-
-	if !allowForwarded {
-		return
-	}
-
-	if h := r.Header.Get("X-Forwarded-Host"); h != "" {
-		host = h
-	}
-
-	if h := r.Header.Get("X-Forwarded-Proto"); h == "http" || h == "https" {
-		proto = h
-	}
-
-	if h := r.Header.Get("Forwarded"); h != "" {
-		if r := reForwardedHost.FindStringSubmatch(h); len(r) == 2 {
-			host = r[1]
-		}
-
-		if r := reForwardedProto.FindStringSubmatch(h); len(r) == 2 {
-			proto = r[1]
-		}
-	}
-
-	return
 }


### PR DESCRIPTION
should use `;` instead of `,` in https://github.com/tus/tusd/blob/f863189009bb9e8a279c7d2a11f3b7503e3a9c7e/pkg/handler/unrouted_handler.go#L24
which causes the returned `host` (when `handler.config.RespectForwardedHeaders` is set to `true`) https://github.com/tus/tusd/blob/f863189009bb9e8a279c7d2a11f3b7503e3a9c7e/pkg/handler/unrouted_handler.go#L1032 to be `upload.example.tld;proto=https;proto-version=` instead of `upload.example.tld`.