### PR TITLE
Customisable FileStore information storage engine for handler.FileInfo

### DIFF
--- a/cmd/tusd/cli/composer.go
+++ b/cmd/tusd/cli/composer.go
@@ -97,7 +97,7 @@ func CreateComposer() {
 			stderr.Fatalf("Unable to ensure directory exists: %s", err)
 		}
 
-		store := filestore.New(dir)
+		store := filestore.NewFileStore(dir)
 		store.UseIn(Composer)
 
 		locker := filelocker.New(dir)

--- a/docs/usage-package.md
+++ b/docs/usage-package.md
@@ -20,9 +20,12 @@ func main() {
 	// If you want to save them on a different medium, for example
 	// a remote FTP server, you can implement your own storage backend
 	// by implementing the tusd.DataStore interface.
-	store := filestore.FileStore{
-		Path: "./uploads",
-	}
+	//
+	// Optionally an InfoStore may be provided for an alternative information storage
+	// engine implementation to the default, eg.
+	//    infoStore := NewAltInfoStore(...)
+	//    store := filestore.NewWithInfoStore("./uploads", infoStore)
+	store := filestore.NewFileStore("./uploads")
 
 	// A storage backend for tusd may consist of multiple different parts which
 	// handle upload creation, locking, termination and so on. The composer is a

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -15,7 +15,11 @@ func main() {
 	// If you want to save them on a different medium, for example
 	// a remote FTP server, you can implement your own storage backend
 	// by implementing the tusd.DataStore interface.
-	store := filestore.New("./uploads")
+	// Optionally an InfoStore may be provided for an alternative information storage
+	// engine implementation to the default, eg.
+	//    infoStore := NewAltInfoStore(...)
+	//    store := filestore.NewWithInfoStore("./uploads", infoStore)
+	store := filestore.NewFileStore("./uploads")
 
 	// A storage backend for tusd may consist of multiple different parts which
 	// handle upload creation, locking, termination and so on. The composer is a

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -15,6 +15,7 @@ func main() {
 	// If you want to save them on a different medium, for example
 	// a remote FTP server, you can implement your own storage backend
 	// by implementing the tusd.DataStore interface.
+	//
 	// Optionally an InfoStore may be provided for an alternative information storage
 	// engine implementation to the default, eg.
 	//    infoStore := NewAltInfoStore(...)

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -15,9 +15,7 @@ func main() {
 	// If you want to save them on a different medium, for example
 	// a remote FTP server, you can implement your own storage backend
 	// by implementing the tusd.DataStore interface.
-	store := filestore.FileStore{
-		Path: "./uploads",
-	}
+	store := filestore.New("./uploads")
 
 	// A storage backend for tusd may consist of multiple different parts which
 	// handle upload creation, locking, termination and so on. The composer is a

--- a/pkg/filestore/fileinfostore.go
+++ b/pkg/filestore/fileinfostore.go
@@ -1,0 +1,48 @@
+package filestore
+
+import (
+	"encoding/json"
+	"github.com/tus/tusd/pkg/handler"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+type fileInfoStore struct {
+	path string
+}
+
+// NewFileInfoStore Creates a new file based information store using the provided directory path for storage
+func NewFileInfoStore(path string) InfoStore {
+	return &fileInfoStore{path}
+}
+
+func (f *fileInfoStore) StoreFileInfo(info handler.FileInfo) error {
+	data, err := json.Marshal(info)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(f.infoPath(info.ID), data, defaultFilePerm)
+}
+
+func (f *fileInfoStore) RetrieveFileInfo(id string) (*handler.FileInfo, error) {
+	info := handler.FileInfo{}
+	data, err := ioutil.ReadFile(f.infoPath(id))
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+func (f *fileInfoStore) DeleteFileInfo(id string) error {
+	return os.Remove(f.infoPath(id))
+}
+
+// infoPath returns the path to the .info file storing the file's info.
+func (f *fileInfoStore) infoPath(id string) string {
+	return filepath.Join(f.path, id+".info")
+}
+

--- a/pkg/filestore/filestore_test.go
+++ b/pkg/filestore/filestore_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 // Test interface implementation of Filestore
-var _ handler.DataStore = FileStore{}
-var _ handler.TerminaterDataStore = FileStore{}
-var _ handler.ConcaterDataStore = FileStore{}
-var _ handler.LengthDeferrerDataStore = FileStore{}
+var _ handler.DataStore = fileStore{}
+var _ handler.TerminaterDataStore = fileStore{}
+var _ handler.ConcaterDataStore = fileStore{}
+var _ handler.LengthDeferrerDataStore = fileStore{}
 
 func TestFilestore(t *testing.T) {
 	a := assert.New(t)
@@ -25,7 +25,7 @@ func TestFilestore(t *testing.T) {
 	tmp, err := ioutil.TempDir("", "tusd-filestore-")
 	a.NoError(err)
 
-	store := FileStore{tmp}
+	store := NewFileStore(tmp)
 	ctx := context.Background()
 
 	// Create new upload
@@ -80,7 +80,7 @@ func TestFilestore(t *testing.T) {
 func TestMissingPath(t *testing.T) {
 	a := assert.New(t)
 
-	store := FileStore{"./path-that-does-not-exist"}
+	store := NewFileStore("./path-that-does-not-exist")
 	ctx := context.Background()
 
 	upload, err := store.NewUpload(ctx, handler.FileInfo{})
@@ -95,7 +95,7 @@ func TestConcatUploads(t *testing.T) {
 	tmp, err := ioutil.TempDir("", "tusd-filestore-concat-")
 	a.NoError(err)
 
-	store := FileStore{tmp}
+	store := NewFileStore(tmp)
 	ctx := context.Background()
 
 	// Create new upload to hold concatenated upload
@@ -153,7 +153,7 @@ func TestDeclareLength(t *testing.T) {
 	tmp, err := ioutil.TempDir("", "tusd-filestore-declare-length-")
 	a.NoError(err)
 
-	store := FileStore{tmp}
+	store := NewFileStore(tmp)
 	ctx := context.Background()
 
 	upload, err := store.NewUpload(ctx, handler.FileInfo{

--- a/pkg/filestore/infostore.go
+++ b/pkg/filestore/infostore.go
@@ -1,0 +1,9 @@
+package filestore
+
+import "github.com/tus/tusd/pkg/handler"
+
+type InfoStore interface {
+	StoreFileInfo(info handler.FileInfo) error
+	RetrieveFileInfo(id string) (*handler.FileInfo, error)
+	DeleteFileInfo(id string) error
+}

--- a/pkg/handler/composer_test.go
+++ b/pkg/handler/composer_test.go
@@ -9,7 +9,7 @@ import (
 func ExampleNewStoreComposer() {
 	composer := handler.NewStoreComposer()
 
-	fs := filestore.New("./data")
+	fs := filestore.NewFileStore("./data")
 	fs.UseIn(composer)
 
 	ml := memorylocker.New()


### PR DESCRIPTION
Add ability to make use of an alternative mechanism for storing/retrieving/removing handler.FileInfo on behalf of a FileStore.

The original implementation is used by default, or when no alternative is provided.

This provides the ability to move away from using '{file_name}.info' files if required (or even just to locate them under an alternative folder using the NewFileInfoStore(path string) factory method), and use another 'information storage backend', eg. DB.

PS: My first PR so apologies if not relevant, feel free to incorporate as you wish :)