### PR TITLE
S3Store: Fix data inconsistency bug when using Upload-Defer-Length

### DIFF
--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -895,7 +895,7 @@ func (upload *s3Upload) concatUsingMultipart(ctx context.Context, partialUploads
 	return upload.FinishUpload(ctx)
 }
 
-func (upload s3Upload) DeclareLength(ctx context.Context, length int64) error {
+func (upload *s3Upload) DeclareLength(ctx context.Context, length int64) error {
 	info, err := upload.GetInfo(ctx)
 	if err != nil {
 		return err

--- a/pkg/s3store/s3store_test.go
+++ b/pkg/s3store/s3store_test.go
@@ -605,6 +605,9 @@ func TestDeclareLength(t *testing.T) {
 
 	err = store.AsLengthDeclarableUpload(upload).DeclareLength(context.Background(), 500)
 	assert.Nil(err)
+	info, err := upload.GetInfo(context.Background())
+	assert.Nil(err)
+	assert.Equal(int64(500), info.Size)
 }
 
 func TestFinishUpload(t *testing.T) {


### PR DESCRIPTION
Fixes #396, which has a rich discussion of the bug. There is a subtle interaction between UnroutedHandler and S3Store when using deferred length. The result is that the last chunk of an upload, if it's less than 5MB, is ignored.