### PR TITLE
Remove "Tus-Resumable" header check for HEAD request.

### DIFF
--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -262,7 +262,7 @@ func (handler *UnroutedHandler) Middleware(h http.Handler) http.Handler {
 		// Test if the version sent by the client is supported
 		// GET methods are not checked since a browser may visit this URL and does
 		// not include this header. This request is not part of the specification.
-		if r.Method != "GET" && r.Header.Get("Tus-Resumable") != "1.0.0" {
+		if r.Method != "GET" && r.Method != "HEAD" && r.Header.Get("Tus-Resumable") != "1.0.0" {
 			handler.sendError(w, r, ErrUnsupportedVersion)
 			return
 		}
@@ -472,6 +472,7 @@ func (handler *UnroutedHandler) HeadFile(w http.ResponseWriter, r *http.Request)
 		w.Header().Set("Upload-Defer-Length", UploadLengthDeferred)
 	} else {
 		w.Header().Set("Upload-Length", strconv.FormatInt(info.Size, 10))
+		w.Header().Set("Content-Length", strconv.FormatInt(info.Size, 10))
 	}
 
 	w.Header().Set("Cache-Control", "no-store")


### PR DESCRIPTION
I faced the issue that some clients, who want to download files from tus directly, send HEAD request to get the  `Content-Length` header.

I've just added the support for that kind of clients.

Signed-off-by: Pavel Kirilin <win10@list.ru>