### PR TITLE
Change timestamp to microseconds precision in log

### DIFF
--- a/cmd/tusd/cli/log.go
+++ b/cmd/tusd/cli/log.go
@@ -7,8 +7,8 @@ import (
 	"github.com/tus/tusd/pkg/handler"
 )
 
-var stdout = log.New(os.Stdout, "[tusd] ", log.Ldate|log.Ltime)
-var stderr = log.New(os.Stderr, "[tusd] ", log.Ldate|log.Ltime)
+var stdout = log.New(os.Stdout, "[tusd] ", log.LstdFlags|log.Lmicroseconds)
+var stderr = log.New(os.Stderr, "[tusd] ", log.LstdFlags|log.Lmicroseconds)
 
 func logEv(logOutput *log.Logger, eventName string, details ...string) {
 	handler.LogEvent(logOutput, eventName, details...)


### PR DESCRIPTION
Currently log config is writing timestamp with second  precision but usually this is not enough to correctly track the requests. 
This PR proposes to use the microsecond precision for the logging timestamps. 

Loking at the standar log package (https://golang.org/pkg/log/#pkg-constants), there is no alternative to the microsecond precision. 