### PR TITLE
Only determine object type based on name after last separator

### DIFF
--- a/pkg/gcsstore/gcsservice.go
+++ b/pkg/gcsstore/gcsservice.go
@@ -351,7 +351,11 @@ loop:
 		if strings.HasSuffix(objAttrs.Name, "info") {
 			continue
 		}
-		split := strings.Split(objAttrs.Name, "_")
+
+		fileNameParts := strings.Split(objAttrs.Name, "/")
+		fileName := fileNameParts[len(fileNameParts)-1]
+
+		split := strings.Split(fileName, "_")
 
 		// If the object name does not split on "_", we have a composed object.
 		// If the object name splits on "_" in to four pieces we


### PR DESCRIPTION
Ran into a problem when Store.ObjectPrefix is set to a path that has an underscore in it. I think this solves it, unless you need to support other separators than "/", which I believe is configurable.