### PR TITLE
Add flag to control CORS Origin header

### DIFF
--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -49,6 +49,7 @@ var Flags struct {
 	ShowVersion             bool
 	ExposeMetrics           bool
 	MetricsPath             string
+	CorsOrigin              string
 	BehindProxy             bool
 	VerboseOutput           bool
 	S3TransferAcceleration  bool
@@ -94,6 +95,7 @@ func ParseFlags() {
 	flag.BoolVar(&Flags.ShowVersion, "version", false, "Print tusd version information")
 	flag.BoolVar(&Flags.ExposeMetrics, "expose-metrics", true, "Expose metrics about tusd usage")
 	flag.StringVar(&Flags.MetricsPath, "metrics-path", "/metrics", "Path under which the metrics endpoint will be accessible")
+	flag.StringVar(&Flags.CorsOrigin, "cors-origin", "", "Explicitly set Access-Control-Allow-Origin header")
 	flag.BoolVar(&Flags.BehindProxy, "behind-proxy", false, "Respect X-Forwarded-* and similar headers which may be set by proxies")
 	flag.BoolVar(&Flags.VerboseOutput, "verbose", true, "Enable verbose logging output")
 	flag.BoolVar(&Flags.S3TransferAcceleration, "s3-transfer-acceleration", false, "Use AWS S3 transfer acceleration endpoint (requires -s3-bucket option and Transfer Acceleration property on S3 bucket to be set)")

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -101,9 +101,9 @@ func Serve() {
 		protocol = "https"
 	}
 
-        if Flags.CorsOrigin != "" {
-                stdout.Printf("CORS origin header is %s", Flags.CorsOrigin)
-        }
+	if Flags.CorsOrigin != "" {
+		stdout.Printf("CORS origin header is %s", Flags.CorsOrigin)
+	}
 
 	if Flags.HttpSock == "" {
 		stdout.Printf("You can now upload files to: %s://%s%s", protocol, address, basepath)

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -26,6 +26,7 @@ func Serve() {
 	config := handler.Config{
 		MaxSize:                 Flags.MaxSize,
 		BasePath:                Flags.Basepath,
+		CorsOrigin:              Flags.CorsOrigin,
 		RespectForwardedHeaders: Flags.BehindProxy,
 		StoreComposer:           Composer,
 		NotifyCompleteUploads:   true,
@@ -99,6 +100,10 @@ func Serve() {
 	if Flags.TLSCertFile != "" && Flags.TLSKeyFile != "" {
 		protocol = "https"
 	}
+
+        if Flags.CorsOrigin != "" {
+                stdout.Printf("CORS origin header is %s", Flags.CorsOrigin)
+        }
 
 	if Flags.HttpSock == "" {
 		stdout.Printf("You can now upload files to: %s://%s%s", protocol, address, basepath)

--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -36,6 +36,10 @@ type Config struct {
 	NotifyCreatedUploads bool
 	// Logger is the logger to use internally, mostly for printing requests.
 	Logger *log.Logger
+	// Explicitly set Access-Control-Allow-Origin in cases where RespectForwardedHeaders
+	// doesn't give you the desired result. This can be the case with some reverse proxies
+	// or a kubernetes setup with complex network routing rules
+	CorsOrigin string
 	// Respect the X-Forwarded-Host, X-Forwarded-Proto and Forwarded headers
 	// potentially set by proxies when generating an absolute URL in the
 	// response to POST requests.
@@ -80,6 +84,13 @@ func (config *Config) validate() error {
 
 	if config.StoreComposer.Core == nil {
 		return errors.New("tusd: StoreComposer in Config needs to contain a non-nil core")
+	}
+
+	if config.CorsOrigin != "" && config.CorsOrigin != "*" && config.CorsOrigin != "null" {
+		_, err := url.ParseRequestURI(config.CorsOrigin)
+		if err != nil {
+			errors.New("tusd: CorsOrigin is not a valid URL")
+		}
 	}
 
 	return nil

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -217,15 +217,15 @@ func (handler *UnroutedHandler) Middleware(h http.Handler) http.Handler {
 
 		header := w.Header()
 
-                var origin = handler.config.CorsOrigin
-                if origin == "" {
-                        origin = r.Header.Get("Origin")
-                }
+		var origin = handler.config.CorsOrigin
+		if origin == "" {
+			origin = r.Header.Get("Origin")
+		}
 
-                if origin != "" {
+		if origin != "" {
 
-                        header.Set("Access-Control-Allow-Origin", origin)
-                        header.Set("Vary", "Origin")
+			header.Set("Access-Control-Allow-Origin", origin)
+			header.Set("Vary", "Origin")
 
 			if r.Method == "OPTIONS" {
 				// Preflight request

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -217,8 +217,15 @@ func (handler *UnroutedHandler) Middleware(h http.Handler) http.Handler {
 
 		header := w.Header()
 
-		if origin := r.Header.Get("Origin"); origin != "" {
-			header.Set("Access-Control-Allow-Origin", origin)
+                var origin = handler.config.CorsOrigin
+                if origin == "" {
+                        origin = r.Header.Get("Origin")
+                }
+
+                if origin != "" {
+
+                        header.Set("Access-Control-Allow-Origin", origin)
+                        header.Set("Vary", "Origin")
 
 			if r.Method == "OPTIONS" {
 				// Preflight request


### PR DESCRIPTION
I added a flag to allow the user to set their own Access-Control-Allow-Origin header. I feel it's proper to be able to set this header because CORS was designed with this use-case in mind. You need to be able explicitly say what origin can access your API. Using a reverse-proxy felt kludgy, because the app already sets CORS headers. It is not offloading that responsibility. This resolves #135 and #386.

I developed this for personal use because I am running tusd in a Kubernetes environment, and because of the way k8s handles network routing via Ingress controller, setting the proper Origin header was infeasible (even with --behind-proxy turned on). Using a reverse proxy felt wrong because k8s already does a lot of network indirection.

I hope you find this useful