### PR TITLE
ci: fix non-failing windows test when it should fail

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -13,17 +13,20 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - name: Install Matrix Go
-      uses: actions/setup-go@v2.1.4
-      with:
-        go-version: ${{ matrix.go-version }}
+      -
+        name: Checkout code
+        uses: actions/checkout@v2.3.5
 
-    - name: Checkout code
-      uses: actions/checkout@v2.3.5
+      -
+        name: Install Go
+        uses: actions/setup-go@v2.1.4
+        with:
+          go-version: ${{ matrix.go-version }}
 
-    - name: Test code
-      env:
-        GO111MODULE: on
-      run: |
-        go test ./pkg/...
-        go vet ./pkg/...
+      -
+        name: Test code
+        env:
+          GO111MODULE: on
+        run: |
+          go test ./pkg/...
+          go vet ./pkg/...

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -12,6 +12,8 @@ jobs:
         go-version: [1.16.x, 1.17.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
+    env:
+      GO111MODULE: on
     steps:
       -
         name: Checkout code
@@ -25,8 +27,10 @@ jobs:
 
       -
         name: Test code
-        env:
-          GO111MODULE: on
         run: |
           go test ./pkg/...
+
+      -
+        name: Vet code
+        run: |
           go vet ./pkg/...


### PR DESCRIPTION
When using a Windows runner, it does not catch the first exit code that comes from when running `go test ./...`, and since `go vet ./...` exits with a non-zero exit code. The step succeeds correctly.

So this PR just moves `go vet ./...` to its separate step