### PR TITLE
s3store: stricter character replacement regexp for x-amz-metadata

### DIFF
--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -94,7 +94,7 @@ import (
 
 // This regular expression matches every character which is not
 // considered valid into a header value according to RFC2616.
-var nonPrintableRegexp = regexp.MustCompile(`[^\x09,\x20-\x7E]`)
+var nonPrintableRegexp = regexp.MustCompile(`[^\x09\x20-\x7E]`)
 
 // See the handler.DataStore interface for documentation about the different
 // methods.

--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -92,11 +92,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
-// This regular expression matches every character which is not defined in the
-// ASCII tables which range from 00 to 7F, inclusive.
-// It also matches the \r and \n characters which are not allowed in values
-// for HTTP headers.
-var nonASCIIRegexp = regexp.MustCompile(`([^\x00-\x7F]|[\r\n])`)
+// This regular expression matches every character which is not
+// considered valid into a header value according to RFC2616.
+var nonPrintableRegexp = regexp.MustCompile(`[^\x09,\x20-\x7E]`)
 
 // See the handler.DataStore interface for documentation about the different
 // methods.
@@ -230,7 +228,7 @@ func (store S3Store) NewUpload(ctx context.Context, info handler.FileInfo) (hand
 	for key, value := range info.MetaData {
 		// Copying the value is required in order to prevent it from being
 		// overwritten by the next iteration.
-		v := nonASCIIRegexp.ReplaceAllString(value, "?")
+		v := nonPrintableRegexp.ReplaceAllString(value, "?")
 		metadata[key] = &v
 	}
 


### PR DESCRIPTION
What's up: some upload-metadata values will be successfully delivered (thanks to b64encode) but then cause an error communicating with S3.

How to reproduce:
```
$ curl -X POST -H 'Upload-Metadata: filename dGVzdC5/Lm1wNA==' [...]
[...]
500 Internal Server Error: s3store: unable to create multipart upload:
RequestError: send request failed
caused by: Post "https://s3.example.net/tusd/d167476518c4ac7e01d3a9bd7beaa0ce?uploads=": net/http: invalid header field value "test.\u007f.mp4" for key X-Amz-Meta-Filename
```

Tracing back lead us here https://cs.opensource.google/go/go/+/master:src/net/http/transport.go;l=528
then here https://pkg.go.dev/golang.org/x/net/http/httpguts#ValidHeaderFieldValue
and eventually refers to a few HTTP RFCs.

From `net/http` implementation (as well as from the RFCs) could be seen that some characters (in particular 0x7f) should not be considered valid, that's why the regexp should be changed.