### PR TITLE
fix: set dependabot to check weekly instead of daily

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,16 +1,16 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: /
     schedule:
-      interval: "daily"
+      interval: weekly
 
   - package-ecosystem: docker
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: daily
+      interval: weekly


### PR DESCRIPTION
I see you also suffer from daily dependabot updates regarding AWS SDK, which they release a new version daily. They do the same in their python SDK, so we've adjusted it down to weekly checks instead of daily.
That way we still get dependabot updates, but not spammed down with it.