### PR TITLE
Fixes #574 #333 #223 - s3store: Feature for saving objects with custom path (including filename and extension) (also merged #668)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 .DS_Store
 ./tusd
 tusd_*_*
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
         -o /go/bin/tusd ./cmd/tusd/main.go
 
 # start a new stage that copies in the binary built in the previous stage
-FROM alpine:3.15.0
+FROM alpine:3.15.1
 WORKDIR /srv/tusd-data
 
 RUN apk add --no-cache ca-certificates jq \

--- a/cmd/tusd/cli/composer.go
+++ b/cmd/tusd/cli/composer.go
@@ -57,10 +57,15 @@ func CreateComposer() {
 			s3Config = s3Config.WithEndpoint(Flags.S3Endpoint).WithS3ForcePathStyle(true)
 		}
 
+		if Flags.AllowCustomFilepath {
+			stdout.Printf("Saving objects with custom path and filename enabled. Use CustomFilepath metadata.")
+		}
+
 		// Derive credentials from default credential chain (env, shared, ec2 instance role)
 		// as per https://github.com/aws/aws-sdk-go#configuring-credentials
 		store := s3store.New(Flags.S3Bucket, s3.New(session.Must(session.NewSession()), s3Config))
 		store.ObjectPrefix = Flags.S3ObjectPrefix
+		store.AllowCustomObjectPath = Flags.AllowCustomFilepath
 		store.PreferredPartSize = Flags.S3PartSize
 		store.DisableContentHashes = Flags.S3DisableContentHashes
 		store.UseIn(Composer)

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -20,6 +20,7 @@ var Flags struct {
 	MaxSize                 int64
 	UploadDir               string
 	Basepath                string
+	AllowCustomFilepath     bool
 	ShowGreeting            bool
 	Timeout                 int64
 	S3Bucket                string
@@ -67,6 +68,7 @@ func ParseFlags() {
 	flag.Int64Var(&Flags.MaxSize, "max-size", 0, "Maximum size of a single upload in bytes")
 	flag.StringVar(&Flags.UploadDir, "upload-dir", "./data", "Directory to store uploads in")
 	flag.StringVar(&Flags.Basepath, "base-path", "/files/", "Basepath of the HTTP server")
+	flag.BoolVar(&Flags.AllowCustomFilepath, "allow-custom-filepath", false, "Allows to customize path and filename (instead of generated ID, basepath respected). Send it with metadata CustomFilepath value. Currently implemented only for s3store (default false)")
 	flag.BoolVar(&Flags.ShowGreeting, "show-greeting", true, "Show the greeting message")
 	flag.Int64Var(&Flags.Timeout, "timeout", 6*1000, "Read timeout for connections in milliseconds.  A zero value means that reads will not timeout")
 	flag.StringVar(&Flags.S3Bucket, "s3-bucket", "", "Use AWS S3 with this bucket as storage backend (requires the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_REGION environment variables to be set)")

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -32,6 +32,7 @@ func Serve() {
 		NotifyTerminatedUploads: true,
 		NotifyUploadProgress:    true,
 		NotifyCreatedUploads:    true,
+		AllowCustomFilepath:     Flags.AllowCustomFilepath,
 	}
 
 	if err := SetupPreHooks(&config); err != nil {
@@ -55,6 +56,10 @@ func Serve() {
 	}
 
 	stdout.Printf("Using %s as the base path.\n", basepath)
+
+	if Flags.AllowCustomFilepath && Flags.S3Bucket == "" {
+		stderr.Fatalf("Custom filepath implemented only for S3. You have not provided -s3-bucket.\n")
+	}
 
 	SetupPostHooks(handler)
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -36,7 +36,7 @@ tusd allows any user to retrieve a previously uploaded file by issuing a HTTP GE
 
 ### How can I keep the original filename for the uploads?
 
-tusd will generate a unique ID for every upload, e.g. `1881febb4343e9b806cad2e676989c0d`, which is also used as the filename for storing the upload. If you want to keep the original filename, e.g. `my_image.png`, you will have to rename the uploaded file manually after the upload is completed. One can use the [`post-finish` hook](https://github.com/tus/tusd/blob/master/docs/hooks.md#post-finish) to be notified once the upload is completed. The client must also be configured to add the filename to the upload's metadata, which can be [accessed inside the hooks](https://github.com/tus/tusd/blob/master/docs/hooks.md#the-hooks-environment) and used for the renaming operation.
+tusd will generate a unique ID for every upload, e.g. `1881febb4343e9b806cad2e676989c0d`, which is also used as the filename for storing the upload. If you want to keep the original filename, e.g. `my_image.png`, you will have to rename the uploaded file manually after the upload is completed. One can use the [`post-finish` hook](https://github.com/tus/tusd/blob/master/docs/hooks.md#post-finish) to be notified once the upload is completed. The client must also be configured to add the filename to the upload's metadata, which can be [accessed inside the hooks](https://github.com/tus/tusd/blob/master/docs/hooks.md#the-hooks-environment) and used for the renaming operation. For S3 storage you can use `-allow-custom-filepath` flag and modify full path to object, including its name and extension with `CustomFilepath` metadata value.
 
 ### Does tusd support Cross-Origin Resource Sharing (CORS)?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,7 +32,7 @@ This error can occur when you are running tusd's disk storage on a file system w
 
 ### How can I prevent users from downloading the uploaded files?
 
-tusd allows any user to retrieve a previously uploaded file by issuing a HTTP GET request to the corresponding upload URL. This is possible as long as the uploaded files on the datastore have not been deleted or moved to another location. While it is a handy feature for debugging and testing your setup, we know that there are situations where you don't want to allow downloads or where you want more control about who downloads what. In these scenarios we recommend to place a proxy in front of tusd which takes on the task of access control or even preventing HTTP GET requests entirely. tusd has no feature built in for controling or disabling downloads on its own because the main focus is on accepting uploads, not serving files.
+tusd allows any user to retrieve a previously uploaded file by issuing a HTTP GET request to the corresponding upload URL. This is possible as long as the uploaded files on the datastore have not been deleted or moved to another location. While it is a handy feature for debugging and testing your setup, we know that there are situations where you don't want to allow downloads or where you want more control about who downloads what. In these scenarios we recommend to place a proxy in front of tusd which takes on the task of access control. tusd has main focus is on accepting uploads, not serving files. But if you want to entirely disable downloads, you can use `disable-download` flag.
 
 ### How can I keep the original filename for the uploads?
 

--- a/docs/usage-binary.md
+++ b/docs/usage-binary.md
@@ -92,6 +92,8 @@ options:
 
 ```
 $ tusd -help
+  -allow-custom-filepath bool
+      Allows to customize path and filename (instead of generated ID, basepath respected). Send it with metadata CustomFilepath value. Currently implemented only for s3store (default false)
   -azure-blob-access-tier string
       Blob access tier when uploading new files (possible values: archive, cool, hot, '')
   -azure-container-access-type string

--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -22,6 +22,10 @@ type Config struct {
 	// absolute URL containing a scheme, e.g. "http://tus.io"
 	BasePath string
 	isAbs    bool
+	// AllowCustomFilepath provides possibility to store files not only
+	// with generated ID but with provided CustomFilepath in metadata, if store
+	// implementation allows it. Require metadata extension. BasePath respected.
+	AllowCustomFilepath bool
 	// NotifyCompleteUploads indicates whether sending notifications about
 	// completed uploads using the CompleteUploads channel should be enabled.
 	NotifyCompleteUploads bool

--- a/pkg/handler/cors_test.go
+++ b/pkg/handler/cors_test.go
@@ -40,7 +40,7 @@ func TestCORS(t *testing.T) {
 			ReqHeader: map[string]string{
 				"Origin": "tus.io",
 			},
-			Code: http.StatusMethodNotAllowed,
+			Code: http.StatusNotFound,
 			ResHeader: map[string]string{
 				"Access-Control-Expose-Headers": "Upload-Offset, Location, Upload-Length, Tus-Version, Tus-Resumable, Tus-Max-Size, Tus-Extension, Upload-Metadata, Upload-Defer-Length, Upload-Concat",
 				"Access-Control-Allow-Origin":   "tus.io",


### PR DESCRIPTION
feat/fix #574 fix #333 fix #223 fix #488
- Checked on S3-compatible service. Uploading & downloading with customized file ID works. Have not checked without s3store. Tests passed.
- bumped alpine runtime in dockerfile
- get rid of [unmaintained](https://github.com/bmizerany/pat/issues/17) routing library bmizerany/pat
- fixed CORS request test (status must be just 404, not 405, consequences of bmizerany/pat)