### PR TITLE
feat: allow user to change fileinfo in callbacks

### DIFF
--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -50,11 +50,11 @@ type Config struct {
 	// property is supplied. If the callback returns nil, the upload will be created.
 	// Otherwise the HTTP request will be aborted. This can be used to implement
 	// validation of upload metadata etc.
-	PreUploadCreateCallback func(hook HookEvent) error
+	PreUploadCreateCallback func(hook *CallbackEvent) error
 	// PreFinishResponseCallback will be invoked after an upload is completed but before
 	// a response is returned to the client. Error responses from the callback will be passed
 	// back to the client. This can be used to implement post-processing validation.
-	PreFinishResponseCallback func(hook HookEvent) error
+	PreFinishResponseCallback func(hook *CallbackEvent) error
 }
 
 func (config *Config) validate() error {

--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"errors"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
 )
@@ -55,6 +56,9 @@ type Config struct {
 	// a response is returned to the client. Error responses from the callback will be passed
 	// back to the client. This can be used to implement post-processing validation.
 	PreFinishResponseCallback func(hook *CallbackEvent) error
+	// PreGetFileInfoCallback will be invoked before read the file information.
+	// This can be used to append upload id with path.
+	PreGetFileInfoCallback func(id *string, r *http.Request) error
 }
 
 func (config *Config) validate() error {

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -534,6 +534,13 @@ func (handler *UnroutedHandler) PatchFile(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	if handler.config.PreGetFileInfoCallback != nil {
+		if err := handler.config.PreGetFileInfoCallback(&id, r); err != nil {
+			handler.sendError(w, r, err)
+			return
+		}
+	}
+
 	if handler.composer.UsesLocker {
 		lock, err := handler.lockUpload(id)
 		if err != nil {
@@ -749,6 +756,13 @@ func (handler *UnroutedHandler) GetFile(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	if handler.config.PreGetFileInfoCallback != nil {
+		if err := handler.config.PreGetFileInfoCallback(&id, r); err != nil {
+			handler.sendError(w, r, err)
+			return
+		}
+	}
+
 	if handler.composer.UsesLocker {
 		lock, err := handler.lockUpload(id)
 		if err != nil {
@@ -874,6 +888,13 @@ func (handler *UnroutedHandler) DelFile(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		handler.sendError(w, r, err)
 		return
+	}
+
+	if handler.config.PreGetFileInfoCallback != nil {
+		if err := handler.config.PreGetFileInfoCallback(&id, r); err != nil {
+			handler.sendError(w, r, err)
+			return
+		}
 	}
 
 	if handler.composer.UsesLocker {


### PR DESCRIPTION
#goal allow user to change file info in callbacks
In my case, I use this in order to be able to independently generate `Upload.ID`
which allow me to change folder in s3 store

Example:
```
	handler, err := tusd.NewUnroutedHandler(tusd.Config{
		BasePath:                "api/v1/files/",
		StoreComposer:           composer,
		NotifyCreatedUploads:    true,
		NotifyUploadProgress:    true,
		NotifyTerminatedUploads: true,
		NotifyCompleteUploads:   true,
		PreUploadCreateCallback: defineFolders,
	})
	if err != nil {
		panic(fmt.Errorf("Unable to create handler: %s", err))
	}
```
```
// defines path and key id for new upload
// {some}/{path}/{uid}
func defineFolders(hook *tusd.CallbackEvent) error {
	folder := "folder_example"
	hook.Upload.ID = fmt.Sprintf("%s/%s", folder, uid())

	return nil
}
```