### PR TITLE
Setting Upload-Offset directly to response

### DIFF
--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -649,7 +649,7 @@ func (handler *UnroutedHandler) writeChunk(c *httpContext, resp HTTPResponse, up
 
 	// Send new offset to client
 	newOffset := offset + bytesWritten
-	resp.Headers["Upload-Offset"] = strconv.FormatInt(newOffset, 10)
+	c.res.Header().Set("Upload-Offset", strconv.FormatInt(newOffset, 10))
 	handler.Metrics.incBytesReceived(uint64(bytesWritten))
 	info.Offset = newOffset
 


### PR DESCRIPTION
The Upload-Offset header is a mandatory response header within the tus protocol. In a scenario using tusd as library by uploading and processing big files the client's request can be kept alive by writing to the ResponseWriter. Doing so would lead to an invalid response without the Upload-Offset header as the response was already written. For that reason it is crucial to directly write mandatory headers like this one to the response.

In general it would also be better for the using application to have a chance to directly write headers into the response in the synchronous callbacks.