### PR TITLE
fix: avoiding `writeChunk` no-op

### DIFF
--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -580,6 +580,7 @@ func (handler *UnroutedHandler) PatchFile(w http.ResponseWriter, r *http.Request
 		// Request was made simply to inform the server of the upload length, no need to call handler.writeChunk
 		if uploadLength == offset {
 			handler.sendResp(w, r, http.StatusNoContent)
+			return
 		}
 
 	}

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -576,6 +576,12 @@ func (handler *UnroutedHandler) PatchFile(w http.ResponseWriter, r *http.Request
 
 		info.Size = uploadLength
 		info.SizeIsDeferred = false
+
+    // Request was made simply to inform the server of the upload length, no need to call handler.writeChunk
+    if (uploadLength == offset) {
+	    handler.sendResp(w, r, http.StatusNoContent)
+    }
+
 	}
 
 	if err := handler.writeChunk(ctx, upload, info, w, r); err != nil {

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -577,10 +577,10 @@ func (handler *UnroutedHandler) PatchFile(w http.ResponseWriter, r *http.Request
 		info.Size = uploadLength
 		info.SizeIsDeferred = false
 
-    // Request was made simply to inform the server of the upload length, no need to call handler.writeChunk
-    if (uploadLength == offset) {
-	    handler.sendResp(w, r, http.StatusNoContent)
-    }
+		// Request was made simply to inform the server of the upload length, no need to call handler.writeChunk
+		if uploadLength == offset {
+			handler.sendResp(w, r, http.StatusNoContent)
+		}
 
 	}
 


### PR DESCRIPTION
Some implementations make a `PATCH` request to inform the server about the upload size after the last byte is sent:

```javascript
// tus-js-client/lib/upload.js
// ...
        // If the upload length is deferred, the upload size was not specified during
        // upload creation. So, if the file reader is done reading, we know the total
        // upload size and can tell the tus server.
        if (this.options.uploadLengthDeferred && done) {
          this._size = this._offset + (value && value.size ? value.size : 0)
          req.setHeader('Upload-Length', this._size)
        }

        if (value === null) {
          return this._sendRequest(req)
        }
        this._emitProgress(this._offset, this._size)
        return this._sendRequest(req, value)
// ...
```

This PR simply adds a check to `PatchFile` so that `writeChunk` isn't called if there are no bytes to write.

