### PR TITLE
Change timestamp to microseconds in log

### DIFF
--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -59,7 +59,7 @@ type Config struct {
 
 func (config *Config) validate() error {
 	if config.Logger == nil {
-		config.Logger = log.New(os.Stdout, "[tusd] ", log.Ldate|log.Ltime)
+		config.Logger = log.New(os.Stdout, "[tusd] ", log.Ldate|log.Lmicroseconds)
 	}
 
 	base := config.BasePath


### PR DESCRIPTION
It is useful to correctly track the requests if log of events other than hooks are written timestamps with microseconds.