### PR TITLE
Docker: add docker secret env parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 .DS_Store
 ./tusd
 tusd_*_*
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,16 +28,20 @@ RUN set -xe \
 FROM alpine:3.16.2
 WORKDIR /srv/tusd-data
 
-RUN apk add --no-cache ca-certificates jq \
+COPY ./docker/entrypoint.sh /usr/local/share/docker-entrypoint.sh
+COPY ./docker/load-env.sh /usr/local/share/load-env.sh
+
+RUN apk add --no-cache ca-certificates jq bash \
     && addgroup -g 1000 tusd \
     && adduser -u 1000 -G tusd -s /bin/sh -D tusd \
     && mkdir -p /srv/tusd-hooks \
-    && chown tusd:tusd /srv/tusd-data
+    && chown tusd:tusd /srv/tusd-data \
+    && chmod +x /usr/local/share/docker-entrypoint.sh /usr/local/share/load-env.sh
 
 COPY --from=builder /go/bin/tusd /usr/local/bin/tusd
 
 EXPOSE 1080
 USER tusd
 
-ENTRYPOINT ["tusd"]
+ENTRYPOINT ["/usr/local/share/docker-entrypoint.sh"]
 CMD [ "--hooks-dir", "/srv/tusd-hooks" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+. /usr/local/share/load-env.sh
+
+exec tusd "$@"

--- a/docker/load-env.sh
+++ b/docker/load-env.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+tusd_env_vars=(
+  AWS_ACCESS_KEY_ID
+  AWS_SECRET_ACCESS_KEY
+  AWS_REGION
+  GCS_SERVICE_ACCOUNT_FILE
+  AZURE_STORAGE_ACCOUNT
+  AZURE_STORAGE_KEY
+)
+
+for env_var in "${tusd_env_vars[@]}"; do
+    file_env_var="${env_var}_FILE"
+
+    if [[ -n "${!file_env_var:-}" ]]; then
+        if [[ -r "${!file_env_var:-}" ]]; then
+            export "${env_var}=$(< "${!file_env_var}")"
+            unset "${file_env_var}"
+        else
+            warn "Skipping export of '${env_var}'. '${!file_env_var:-}' is not readable."
+        fi
+    fi
+done
+
+unset tusd_env_vars

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -58,3 +58,16 @@ To make your setup easier, tusd already includes the necessary CORS configuratio
  * `Upload-Concat`: A tus specific header used to indicate if the containing HTTP request is the final request for uploading a file or not. See [here](https://tus.io/protocols/resumable-upload.html#upload-concat) for details.
 
 If you are looking for a way to communicate additional information from a client to a server, use the `Upload-Metadata` header.
+
+### How to use Docker Secrets for credentials (Swarm mode only)
+
+Example usage with "minio"/S3 (AWS). Create the secrets:
+
+```bash
+printf "minio" | docker secret create minio-username -
+printf "miniosecret" | docker secret create minio-password -
+```
+
+Those commands create two secrets which are used inside the example [docker-compose.yml](../examples/docker-compose.yml) file.
+The provided example assumes, that you also have a service named "minio" inside the same Docker Network.
+We just append a _FILE suffix to the corresponding environment variables. The contents of the mounted file will be added to the environment variable without _FILE suffix.

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.9"
+services:
+    tusd:
+      image: tusproject/tusd:custom # tusproject/tusd:v1.9
+      command: -verbose -s3-bucket mybucket -s3-endpoint http://minio:9000
+      volumes:
+        - tusd:/data
+      environment:
+        - AWS_REGION=us-east-1
+        - AWS_URL=http://minio:9000
+        - AWS_ACCESS_KEY_ID_FILE=/run/secrets/minio-username
+        - AWS_SECRET_ACCESS_KEY_FILE=/run/secrets/minio-password
+      secrets:
+        - minio-username
+        - minio-password
+      networks:
+        - tusd
+
+volumes:
+  tusd:
+
+secrets:
+  minio-username:
+    external: true
+  minio-password:
+    external: true
+
+networks:
+  tusd:

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
     tusd:
-      image: tusproject/tusd:custom # tusproject/tusd:v1.9
+      image: tusproject/tusd:v1.9
       command: -verbose -s3-bucket mybucket -s3-endpoint http://minio:9000
       volumes:
         - tusd:/data

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -7,7 +7,6 @@ services:
         - tusd:/data
       environment:
         - AWS_REGION=us-east-1
-        - AWS_URL=http://minio:9000
         - AWS_ACCESS_KEY_ID_FILE=/run/secrets/minio-username
         - AWS_SECRET_ACCESS_KEY_FILE=/run/secrets/minio-password
       secrets:


### PR DESCRIPTION
This pull request resolves the requested feature #799 to read mounted Docker Secrets from /run/secrets folder into corresponding ENV vars. The ENV vars are defined inside **docker/load-env.sh** script. If a _FILE suffix is added to an ENV var, the script tries to read the corresponding file and sets the environment variable without _FILE suffix to the same value.

![grafik](https://user-images.githubusercontent.com/945323/189686070-f2abe99c-15a2-42db-8a5e-70440cb55b57.png)
![grafik](https://user-images.githubusercontent.com/945323/189686135-72a373c4-f953-4e35-8577-671e462fbc1d.png)
