### PR TITLE
Added Azure SAS Token Authentication

### DIFF
--- a/cmd/tusd/cli/composer.go
+++ b/cmd/tusd/cli/composer.go
@@ -135,8 +135,10 @@ func CreateComposer() {
 		}
 
 		accountKey := os.Getenv("AZURE_STORAGE_KEY")
-		if accountKey == "" {
-			stderr.Fatalf("No service account key for Azure BlockBlob Storage using the AZURE_STORAGE_KEY environment variable.\n")
+		sasUrl := os.Getenv("AZURE_STORAGE_SAS_URL")
+
+		if accountKey == "" && sasUrl == "" {
+			stderr.Fatalf("No service account key or SAS URL for Azure BlockBlob Storage using the AZURE_STORAGE_KEY or AZURE_STORAGE_SAS_URL environment variable.\n")
 		}
 
 		azureEndpoint := Flags.AzEndpoint
@@ -152,6 +154,7 @@ func CreateComposer() {
 
 		azConfig := &azurestore.AzConfig{
 			AccountName:         accountName,
+			SasUrl:              sasUrl,
 			AccountKey:          accountKey,
 			ContainerName:       Flags.AzStorage,
 			ContainerAccessType: Flags.AzContainerAccessType,

--- a/pkg/azurestore/azureservice.go
+++ b/pkg/azurestore/azureservice.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -351,6 +352,9 @@ func getSasToken(sasUrl string) (sas string, err error) {
 		return "", err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return "", errors.New("Error at requesting SAS Token: " + resp.Status)
+	}
 	sasResponse, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		return "", readErr

--- a/pkg/azurestore/azureservice.go
+++ b/pkg/azurestore/azureservice.go
@@ -152,8 +152,8 @@ func NewAzureService(config *AzConfig) (AzService, error) {
 func (service *azService) NewBlob(ctx context.Context, name string) (AzBlob, error) {
 	var fileBlob AzBlob
 	url := service.ContainerURL.URL()
-	skeParam := url.Query().Get("ske")
-	if skeParam != "" {
+	if service.SasUrl != "" {
+		skeParam := url.Query().Get("ske")
 		sasEndDate, _ := time.Parse(time.RFC3339, skeParam)
 		if sasEndDate.Before(time.Now()) {
 			// Renew SAS and append it to URL
@@ -355,5 +355,6 @@ func getSasToken(sasUrl string) (sas string, err error) {
 	if readErr != nil {
 		return "", readErr
 	}
+	fmt.Println("Requested SAS Token.")
 	return string(sasResponse), nil
 }


### PR DESCRIPTION
This pull request allows to authenticate in Azure with a SAS token. For this, the env var **AZURE_STORAGE_SAS_URL** must be set. 

If no AZURE_STORAGE_KEY is set, a SAS token is requested from the AZURE_STORAGE_SAS_URL. The SAS token is initially requested in the NewAzureService func. Additionally, the NewBlob func checks if the token is still valid and fetches a new one if necessary.

**If AZURE_STORAGE_KEY is set, the key is used for authentication.**
