### PR TITLE
filestore: keep ID passed to NewUpload, if available

### DIFF
--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -49,9 +49,10 @@ func (store FileStore) UseIn(composer *handler.StoreComposer) {
 }
 
 func (store FileStore) NewUpload(ctx context.Context, info handler.FileInfo) (handler.Upload, error) {
-	id := uid.Uid()
-	binPath := store.binPath(id)
-	info.ID = id
+	if info.ID == "" { 
+		info.ID = uid.Uid()
+	}
+	binPath := store.binPath(info.ID)
 	info.Storage = map[string]string{
 		"Type": "filestore",
 		"Path": binPath,

--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -73,8 +73,8 @@ func (store FileStore) NewUpload(ctx context.Context, info handler.FileInfo) (ha
 
 	upload := &fileUpload{
 		info:     info,
-		infoPath: store.infoPath(id),
-		binPath:  store.binPath(id),
+		infoPath: store.infoPath(info.ID),
+		binPath:  binPath,
 	}
 
 	// writeInfo creates the file by itself if necessary


### PR DESCRIPTION
`info.ID` could be set external e.g. by `config.PreUploadCreateCallback`

is already set in
- s3store (complicated)
- gcsstore (get from there)
- azurestore (get from there)