### PR TITLE
fix(ci): build arm64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,6 +68,7 @@ jobs:
           build-args: |
             GIT_VERSION=${{ env.GIT_VERSION }}
             GIT_COMMIT=${{ github.sha }}
+          platforms: linux/amd64,linux/arm64/v8
 
   build-binary:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Newer Mac computers with their M1 chips use the ARM architecture [1]. Currently there is no docker image for postgraphile published to Docker Hub supporting the `arm64` platform, only for `amd64`. This commit adds compilation for an ARM image as well, so that developers on newer Mac computers can use postgraphile inside a container as well.

[1] https://en.wikipedia.org/wiki/Apple_M1

## Performance impact

The build time will be longer. Especially cross-platform compilation for ARM will take longer than AMD compilation on AMD ci workers due to necessary QEMU virtualization.

## Additional info

I chose `fix` as the type, as it does not really add a new feature to tusd but adds a missing platform for Mac.