### PR TITLE
fix: make FileInfo editable in PreUploadCreateCallback Hook

### DIFF
--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -91,13 +91,13 @@ type HTTPRequest struct {
 type HookEvent struct {
 	// Upload contains information about the upload that caused this hook
 	// to be fired.
-	Upload FileInfo
+	Upload *FileInfo
 	// HTTPRequest contains details about the HTTP request that reached
 	// tusd.
 	HTTPRequest HTTPRequest
 }
 
-func newHookEvent(info FileInfo, r *http.Request) HookEvent {
+func newHookEvent(info *FileInfo, r *http.Request) HookEvent {
 	return HookEvent{
 		Upload: info,
 		HTTPRequest: HTTPRequest{
@@ -352,7 +352,7 @@ func (handler *UnroutedHandler) PostFile(w http.ResponseWriter, r *http.Request)
 	}
 
 	if handler.config.PreUploadCreateCallback != nil {
-		if err := handler.config.PreUploadCreateCallback(newHookEvent(info, r)); err != nil {
+		if err := handler.config.PreUploadCreateCallback(newHookEvent(&info, r)); err != nil {
 			handler.sendError(w, r, err)
 			return
 		}

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -381,7 +381,7 @@ func (handler *UnroutedHandler) PostFile(w http.ResponseWriter, r *http.Request)
 	handler.log("UploadCreated", "id", id, "size", i64toa(size), "url", url)
 
 	if handler.config.NotifyCreatedUploads {
-		handler.CreatedUploads <- newHookEvent(info, r)
+		handler.CreatedUploads <- newHookEvent(&info, r)
 	}
 
 	if isFinal {
@@ -393,7 +393,7 @@ func (handler *UnroutedHandler) PostFile(w http.ResponseWriter, r *http.Request)
 		info.Offset = size
 
 		if handler.config.NotifyCompleteUploads {
-			handler.CompleteUploads <- newHookEvent(info, r)
+			handler.CompleteUploads <- newHookEvent(&info, r)
 		}
 	}
 

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -702,7 +702,7 @@ func (handler *UnroutedHandler) finishUploadIfComplete(ctx context.Context, uplo
 
 		// ... allow the hook callback to run before sending the response
 		if handler.config.PreFinishResponseCallback != nil {
-			if err := handler.config.PreFinishResponseCallback(newHookEvent(info, r)); err != nil {
+			if err := handler.config.PreFinishResponseCallback(newHookEvent(&info, r)); err != nil {
 				return err
 			}
 		}
@@ -711,7 +711,7 @@ func (handler *UnroutedHandler) finishUploadIfComplete(ctx context.Context, uplo
 
 		// ... send the info out to the channel
 		if handler.config.NotifyCompleteUploads {
-			handler.CompleteUploads <- newHookEvent(info, r)
+			handler.CompleteUploads <- newHookEvent(&info, r)
 		}
 	}
 

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -645,7 +645,7 @@ func (handler *UnroutedHandler) writeChunk(ctx context.Context, upload Upload, i
 		}()
 
 		if handler.config.NotifyUploadProgress {
-			stopProgressEvents := handler.sendProgressMessages(newHookEvent(info, r), reader)
+			stopProgressEvents := handler.sendProgressMessages(newHookEvent(&info, r), reader)
 			defer close(stopProgressEvents)
 		}
 
@@ -904,7 +904,7 @@ func (handler *UnroutedHandler) terminateUpload(ctx context.Context, upload Uplo
 	}
 
 	if handler.config.NotifyTerminatedUploads {
-		handler.TerminatedUploads <- newHookEvent(info, r)
+		handler.TerminatedUploads <- newHookEvent(&info, r)
 	}
 
 	handler.Metrics.incUploadsTerminated()


### PR DESCRIPTION
it would be nice to overwrite the `hook.Upload.ID` by the PreUploadCreateCallback.