### PR TITLE
ci: Automatically use latest Go versions

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18.x, 1.19.x]
+        go-version: [stable, oldstable]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,10 +81,10 @@ jobs:
         uses: actions/checkout@v3
 
       -
-        name: Install Go 1.19
+        name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19.5'
+          go-version: 'stable'
 
       -
         name: Build TUSD


### PR DESCRIPTION
Provided by https://github.com/actions/setup-go/releases/tag/v3.5.0