### PR TITLE
Graceful shutdown

### DIFF
--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -61,6 +61,7 @@ var Flags struct {
 	TLSCertFile             string
 	TLSKeyFile              string
 	TLSMode                 string
+	ShutdownTimeout         int64
 }
 
 func ParseFlags() {
@@ -115,6 +116,7 @@ func ParseFlags() {
 	flag.StringVar(&Flags.TLSCertFile, "tls-certificate", "", "Path to the file containing the x509 TLS certificate to be used. The file should also contain any intermediate certificates and the CA certificate.")
 	flag.StringVar(&Flags.TLSKeyFile, "tls-key", "", "Path to the file containing the key for the TLS certificate.")
 	flag.StringVar(&Flags.TLSMode, "tls-mode", "tls12", "Specify which TLS mode to use; valid modes are tls13, tls12, and tls12-strong.")
+	flag.Int64Var(&Flags.ShutdownTimeout, "shutdown-timeout", 5*1000, "Timeout in milliseconds for closing connections gracefully during shutdown. After the timeout, tusd will exit regardless of any open connection.")
 	flag.Parse()
 
 	SetEnabledHooks()

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -116,7 +116,7 @@ func ParseFlags() {
 	flag.StringVar(&Flags.TLSCertFile, "tls-certificate", "", "Path to the file containing the x509 TLS certificate to be used. The file should also contain any intermediate certificates and the CA certificate.")
 	flag.StringVar(&Flags.TLSKeyFile, "tls-key", "", "Path to the file containing the key for the TLS certificate.")
 	flag.StringVar(&Flags.TLSMode, "tls-mode", "tls12", "Specify which TLS mode to use; valid modes are tls13, tls12, and tls12-strong.")
-	flag.Int64Var(&Flags.ShutdownTimeout, "shutdown-timeout", 5*1000, "Timeout in milliseconds for closing connections gracefully during shutdown. After the timeout, tusd will exit regardless of any open connection.")
+	flag.Int64Var(&Flags.ShutdownTimeout, "shutdown-timeout", 10*1000, "Timeout in milliseconds for closing connections gracefully during shutdown. After the timeout, tusd will exit regardless of any open connection.")
 	flag.Parse()
 
 	SetEnabledHooks()

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -201,7 +201,7 @@ func setupSignalHandler(server *http.Server, handler *handler.Handler) <-chan st
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 
 	// Signal to the handler that it should stop all long running requests if we shut down
-	server.RegisterOnShutdown(handler.StopLongRunningRequests)
+	server.RegisterOnShutdown(handler.InterruptRequestHandling)
 
 	go func() {
 		// First interrupt signal

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -211,7 +211,7 @@ func setupSignalHandler(server *http.Server, handler *handler.Handler) <-chan st
 		}()
 
 		// Shutdown the server, but with a user-specified timeout
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(Flags.ShutdownTimeout)*time.Millisecond)
 		defer cancel()
 
 		err := server.Shutdown(ctx)

--- a/docs/usage-binary.md
+++ b/docs/usage-binary.md
@@ -224,3 +224,13 @@ $ tusd -help
       Print tusd version information
 
 ```
+
+## Graceful shutdown
+
+If tusd receives a SIGINT or SIGTERM signal, it will initiate a graceful shutdown. SIGINT is usually emitted by pressing Ctrl+C inside the terminal that is running tusd. SIGINT and SIGTERM can also be emitted using the [`kill(1)`](https://man7.org/linux/man-pages/man1/kill.1.html) utility on Unix. Signals in that sense do not exist on Windows, so please refer to the [Go documentation](https://pkg.go.dev/os/signal#hdr-Windows) on how different events are translated into signals on Windows.
+
+Once the graceful shutdown is started, tusd will stop listening on its port and won't accept new connections anymore. Idle connections are closed down. Already running requests will be given a grace period to complete before their connections are closed as well. PATCH and POST requests with a request body are interrupted, so that data stores can gracefully finish saving all the received data until that point. If all requests have been completed, tusd will exit.
+
+If not all requests have been completed in the period defined by the `-shutdown-timeout` flag, tusd will exit regardless. By default, tusd will give all requests 10 seconds to complete their processing. If you do not want to wait for requests, use `-shutdown-timeout=0`.
+
+tusd will also immediately exit if it receives a second SIGINT or SIGTERM signal. It will also always exit immediately if a SIGKILL is received.

--- a/pkg/handler/body_reader.go
+++ b/pkg/handler/body_reader.go
@@ -31,6 +31,10 @@ func (r *bodyReader) Read(b []byte) (int, error) {
 		return 0, io.EOF
 	}
 
+	// TODO: Mask certain errors that we can safely ignore later on:
+	// io.EOF, io.UnexpectedEOF, io.ErrClosedPipe,
+	// read tcp 127.0.0.1:1080->127.0.0.1:56953: read: connection reset by peer,
+	// read tcp 127.0.0.1:1080->127.0.0.1:9375: i/o timeout
 	n, err := r.reader.Read(b)
 	atomic.AddInt64(&r.bytesCounter, int64(n))
 	r.err = err

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -134,7 +134,20 @@ func NewUnroutedHandler(config Config) (*UnroutedHandler, error) {
 	return handler, nil
 }
 
-func (handler UnroutedHandler) StopLongRunningRequests() {
+// InterruptRequestHandling attempts to interrupt long running requests, so
+// the server can shutdown gracefully. This function should not be used on
+// its own, but as part of http.Server.Shutdown. For example:
+//
+//	server := &http.Server{
+//		Handler: handler,
+//	}
+//	server.RegisterOnShutdown(handler.InterruptRequestHandling)
+//	server.Shutdown(ctx)
+//
+// Note: currently, this function only interrupts POST and PATCH requests
+// with a request body. In the future, this might be extended to HEAD, DELETE
+// and GET requests.
+func (handler UnroutedHandler) InterruptRequestHandling() {
 	close(handler.serverCtx)
 }
 

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -43,6 +43,7 @@ var (
 	ErrUploadStoppedByServer            = NewError("ERR_UPLOAD_STOPPED", "upload has been stopped by server", http.StatusBadRequest)
 	ErrUploadRejectedByServer           = NewError("ERR_UPLOAD_REJECTED", "upload creation has been rejected by server", http.StatusBadRequest)
 	ErrUploadInterrupted                = NewError("ERR_UPLAOD_INTERRUPTED", "upload has been interrupted by another request for this upload resource", http.StatusBadRequest)
+	ErrServerShutdown                   = NewError("ERR_SERVER_SHUTDOWN", "request has been interrupted because the server is shutting down", http.StatusInternalServerError)
 
 	// TODO: These two responses are 500 for backwards compatability. We should discuss
 	// whether it is better to more them to 4XX status codes.
@@ -60,6 +61,7 @@ type UnroutedHandler struct {
 	basePath      string
 	logger        *log.Logger
 	extensions    string
+	serverCtx     chan struct{}
 
 	// CompleteUploads is used to send notifications whenever an upload is
 	// completed by a user. The HookEvent will contain information about this
@@ -126,9 +128,14 @@ func NewUnroutedHandler(config Config) (*UnroutedHandler, error) {
 		logger:            config.Logger,
 		extensions:        extensions,
 		Metrics:           newMetrics(),
+		serverCtx:         make(chan struct{}),
 	}
 
 	return handler, nil
+}
+
+func (handler UnroutedHandler) StopLongRunningRequests() {
+	close(handler.serverCtx)
 }
 
 // SupportedExtensions returns a comma-separated list of the supported tus extensions.
@@ -596,18 +603,28 @@ func (handler *UnroutedHandler) writeChunk(c *httpContext, resp HTTPResponse, up
 		// We use a context object to allow the hook system to cancel an upload
 		uploadCtx, stopUpload := context.WithCancel(context.Background())
 		info.stopUpload = stopUpload
+
 		// terminateUpload specifies whether the upload should be deleted after
 		// the write has finished
 		terminateUpload := false
+
+		serverShutDown := false
+
 		// Cancel the context when the function exits to ensure that the goroutine
 		// is properly cleaned up
 		defer stopUpload()
 
 		go func() {
-			// Interrupt the Read() call from the request body
-			<-uploadCtx.Done()
-			// TODO: Consider using CloseWithError function from BodyReader
-			terminateUpload = true
+			select {
+			case <-uploadCtx.Done():
+				// uploadCtx is done if the upload is stopped by a post-receive hook
+				terminateUpload = true
+			case <-handler.serverCtx:
+				// serverCtx is closed if the server is being shut down
+				serverShutDown = true
+			}
+
+			// interrupt the Read() calls from the request body
 			r.Body.Close()
 		}()
 
@@ -638,6 +655,11 @@ func (handler *UnroutedHandler) writeChunk(c *httpContext, resp HTTPResponse, up
 		// TODO: Include a custom reason for the end user why the upload was stopped.
 		if terminateUpload {
 			err = ErrUploadStoppedByServer
+		}
+
+		// If the server is closing down, send an error response indicating this.
+		if serverShutDown {
+			err = ErrServerShutdown
 		}
 	}
 
@@ -1104,6 +1126,7 @@ func (handler *UnroutedHandler) lockUpload(c *httpContext, id string) (Lock, err
 	releaseLock := func() {
 		if c.body != nil {
 			handler.log("UploadInterrupted", "id", id, "requestId", getRequestId(c.req))
+			// TODO: Consider replacing this with a channel or a context
 			c.body.closeWithError(ErrUploadInterrupted)
 		}
 	}


### PR DESCRIPTION
This PR implements a graceful shutdown for tusd. Once it receives a shutdown instruction, it will stop listening and try to close down all uploads properly, so that data stores and locker can properly clean up. It waits for a specific period after the first shutdown instructions. If the requests are not all closed down at this point, it will exit regardless.

Closes #395 

Tasks:
- [x] Consider doing this for SIGTERM on Linux as well
- [x] Make wait period configurable
- [x] Allow to disable this behavior
- [x] Test this on Windows
- [x] Documentation