### PR TITLE
Provide values from request context to store

### DIFF
--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -74,7 +74,13 @@ type Config struct {
 	// If the error is non-nil, the error will be forwarded to the client. Furthermore,
 	// HTTPResponse will be ignored and the error value can contain values for the HTTP response.
 	PreFinishResponseCallback func(hook HookEvent) (HTTPResponse, error)
-	// GracefulRequestCompletionDuration
+	// GracefulRequestCompletionDuration is the timeout for operations to complete after an HTTP
+	// request has ended (successfully or by error). For example, if an HTTP request is interrupted,
+	// instead of stopping immediately, the handler and data store will be given some additional
+	// time to wrap up their operations and save any uploaded data. GracefulRequestCompletionDuration
+	// controls this time.
+	// See HookEvent.Context for more details.
+	// Defaults to 10s.
 	GracefulRequestCompletionDuration time.Duration
 }
 

--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -74,6 +74,8 @@ type Config struct {
 	// If the error is non-nil, the error will be forwarded to the client. Furthermore,
 	// HTTPResponse will be ignored and the error value can contain values for the HTTP response.
 	PreFinishResponseCallback func(hook HookEvent) (HTTPResponse, error)
+	// GracefulRequestCompletionDuration
+	GracefulRequestCompletionDuration time.Duration
 }
 
 func (config *Config) validate() error {
@@ -109,6 +111,10 @@ func (config *Config) validate() error {
 
 	if config.UploadProgressInterval <= 0 {
 		config.UploadProgressInterval = 1 * time.Second
+	}
+
+	if config.GracefulRequestCompletionDuration <= 0 {
+		config.GracefulRequestCompletionDuration = 10 * time.Second
 	}
 
 	return nil

--- a/pkg/handler/context.go
+++ b/pkg/handler/context.go
@@ -20,7 +20,8 @@ type httpContext struct {
 
 func (h UnroutedHandler) newContext(w http.ResponseWriter, r *http.Request) *httpContext {
 	return &httpContext{
-		// TODO: Try to reuse the request's context in the future
+		// We construct a new context which gets cancelled with a delay.
+		// See HookEvent.Context for more details.
 		Context: newDelayedContext(r.Context(), h.config.GracefulRequestCompletionDuration),
 		res:     w,
 		req:     r,
@@ -29,6 +30,8 @@ func (h UnroutedHandler) newContext(w http.ResponseWriter, r *http.Request) *htt
 }
 
 func (c httpContext) Value(key any) any {
+	// We overwrite the Value function to ensure that the values from the request
+	// context are returned because c.Context does not contain any values.
 	return c.req.Context().Value(key)
 }
 

--- a/pkg/handler/context.go
+++ b/pkg/handler/context.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"net/http"
+	"time"
 )
 
 // httpContext is wrapper around context.Context that also carries the
@@ -17,12 +18,31 @@ type httpContext struct {
 	body *bodyReader
 }
 
-func newContext(w http.ResponseWriter, r *http.Request) *httpContext {
+func (h UnroutedHandler) newContext(w http.ResponseWriter, r *http.Request) *httpContext {
 	return &httpContext{
 		// TODO: Try to reuse the request's context in the future
-		Context: context.Background(),
+		Context: newDelayedContext(r.Context(), h.config.GracefulRequestCompletionDuration),
 		res:     w,
 		req:     r,
 		body:    nil, // body can be filled later for PATCH requests
 	}
+}
+
+func (c httpContext) Value(key any) any {
+	return c.req.Context().Value(key)
+}
+
+// newDelayedContext returns a context that is cancelled with a delay. If the parent context
+// is done, the new context will also be cancelled but only after waiting the specified delay.
+// Note: The parent context MUST be cancelled or otherwise this will leak resources. In the
+// case of http.Request.Context, the net/http package ensures that the context is always cancelled.
+func newDelayedContext(parent context.Context, delay time.Duration) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-parent.Done()
+		<-time.After(delay)
+		cancel()
+	}()
+
+	return ctx
 }

--- a/pkg/handler/context_test.go
+++ b/pkg/handler/context_test.go
@@ -1,0 +1,139 @@
+package handler_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/tus/tusd/v2/pkg/handler"
+)
+
+// contextValueMatcher is a gomock.Matcher that tests if a given object
+// is a context.Context and has a key with an expected value.
+type contextValueMatcher struct {
+	key           any
+	expectedValue any
+}
+
+func (m contextValueMatcher) Matches(a interface{}) bool {
+	ctx, ok := a.(context.Context)
+	if !ok {
+		return false
+	}
+
+	value := ctx.Value(m.key)
+	return gomock.Eq(m.expectedValue).Matches(value)
+}
+
+func (m contextValueMatcher) String() string {
+	return fmt.Sprintf("is a context.Context and has value %v (%T) under key %v", m.expectedValue, m.expectedValue, m.key)
+}
+
+// contextCancelMatcher is a gomock.Matcher that tests if a given object
+// is a context.Context, which will be cancelled within a specific delay.
+type contextCancelMatcher struct {
+	minDelay time.Duration
+	maxDelay time.Duration
+}
+
+func (m contextCancelMatcher) Matches(a interface{}) bool {
+	ctx, ok := a.(context.Context)
+	if !ok {
+		return false
+	}
+
+	start := time.Now()
+	select {
+	case <-ctx.Done():
+		delay := time.Since(start)
+		fmt.Println(delay, m.minDelay)
+		return delay > m.minDelay
+	case <-time.After(m.maxDelay):
+		fmt.Println("noo")
+		return false
+	}
+}
+
+func (m contextCancelMatcher) String() string {
+	return "is a context.Context that should be cancelled"
+}
+
+func TestContext(t *testing.T) {
+	SubTest(t, "Value", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		upload := NewMockFullUpload(ctrl)
+
+		gomock.InOrder(
+			store.EXPECT().GetUpload(contextValueMatcher{"hello", "world"}, "yes").Return(upload, nil),
+			upload.EXPECT().GetInfo(contextValueMatcher{"hello", "world"}).Return(FileInfo{
+				Offset: 10,
+				Size:   40,
+			}, nil),
+		)
+
+		handler, _ := NewHandler(Config{
+			StoreComposer: composer,
+		})
+
+		(&httpTest{
+			Context: context.WithValue(context.Background(), "hello", "world"),
+			Method:  "HEAD",
+			URL:     "yes",
+			ReqHeader: map[string]string{
+				"Tus-Resumable": "1.0.0",
+			},
+			Code: http.StatusOK,
+			ResHeader: map[string]string{
+				"Upload-Offset": "10",
+				"Upload-Length": "40",
+			},
+		}).Run(handler, t)
+	})
+
+	SubTest(t, "Cancel", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		upload := NewMockFullUpload(ctrl)
+
+		gomock.InOrder(
+			store.EXPECT().GetUpload(gomock.Any(), "yes").Return(upload, nil),
+			upload.EXPECT().GetInfo(gomock.Any()).Return(FileInfo{
+				Offset: 10,
+				Size:   40,
+			}, nil),
+			upload.EXPECT().WriteChunk(contextCancelMatcher{150 * time.Millisecond, 250 * time.Millisecond}, int64(10), gomock.Any()),
+		)
+
+		handler, _ := NewHandler(Config{
+			StoreComposer:                     composer,
+			GracefulRequestCompletionDuration: 100 * time.Millisecond,
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			<-time.After(100 * time.Millisecond)
+			cancel()
+		}()
+
+		(&httpTest{
+			Context: ctx,
+			Method:  "PATCH",
+			URL:     "yes",
+			ReqHeader: map[string]string{
+				"Tus-Resumable": "1.0.0",
+				"Upload-Offset": "10",
+				"Content-Type":  "application/offset+octet-stream",
+			},
+			ReqBody: strings.NewReader("hello"),
+			Code:    http.StatusNoContent,
+			ResHeader: map[string]string{
+				"Upload-Offset": "10",
+			},
+		}).Run(handler, t)
+	})
+}

--- a/pkg/handler/datastore.go
+++ b/pkg/handler/datastore.go
@@ -107,6 +107,11 @@ type Upload interface {
 	FinishUpload(ctx context.Context) error
 }
 
+// DataStore is the base interface for storages to implement. It provides functions
+// to create new uploads and fetch existing ones.
+//
+// Note: the context values passed to all functions is not the request's context,
+// but a similar context. See HookEvent.Context for more details.
 type DataStore interface {
 	// Create a new upload using the size as the file's length. The method must
 	// return an unique id which is used to identify the upload. If no backend

--- a/pkg/handler/hooks.go
+++ b/pkg/handler/hooks.go
@@ -6,6 +6,19 @@ import (
 
 // HookEvent represents an event from tusd which can be handled by the application.
 type HookEvent struct {
+	// Context provides access to the context from the HTTP request. This context is
+	// not the exact value as the request context from http.Request.Context() but
+	// a similar context that retains the same values as the request context. In
+	// addition, Context will be cancelled after a short delay when the request context
+	// is done. This delay is controlled by Config.GracefulRequestCompletionDuration.
+	//
+	// The reason is that we want stores to be able to continue processing a request after
+	// its context has been cancelled. For example, assume a PATCH request is incoming. If
+	// the end-user pauses the upload, the connection is closed causing the request context
+	// to be cancelled immediately. However, we want the store to be able to save the last
+	// few bytes that were transmitted before the request was aborted. To allow this, we
+	// copy the request context but cancel it with a brief delay to give the data store
+	// time to finish its operations.
 	Context context.Context `json:"-"`
 	// Upload contains information about the upload that caused this hook
 	// to be fired.

--- a/pkg/handler/hooks.go
+++ b/pkg/handler/hooks.go
@@ -1,9 +1,12 @@
 package handler
 
-import "net/http"
+import (
+	"context"
+)
 
 // HookEvent represents an event from tusd which can be handled by the application.
 type HookEvent struct {
+	Context context.Context `json:"-"`
 	// Upload contains information about the upload that caused this hook
 	// to be fired.
 	Upload FileInfo
@@ -12,20 +15,21 @@ type HookEvent struct {
 	HTTPRequest HTTPRequest
 }
 
-func newHookEvent(info FileInfo, r *http.Request) HookEvent {
+func newHookEvent(c *httpContext, info FileInfo) HookEvent {
 	// The Host header field is not present in the header map, see https://pkg.go.dev/net/http#Request:
 	// > For incoming requests, the Host header is promoted to the
 	// > Request.Host field and removed from the Header map.
 	// That's why we add it back manually.
-	r.Header.Set("Host", r.Host)
+	c.req.Header.Set("Host", c.req.Host)
 
 	return HookEvent{
-		Upload: info,
+		Context: c,
+		Upload:  info,
 		HTTPRequest: HTTPRequest{
-			Method:     r.Method,
-			URI:        r.RequestURI,
-			RemoteAddr: r.RemoteAddr,
-			Header:     r.Header,
+			Method:     c.req.Method,
+			URI:        c.req.RequestURI,
+			RemoteAddr: c.req.RemoteAddr,
+			Header:     c.req.Header,
 		},
 	}
 }

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -233,7 +233,7 @@ func (handler *UnroutedHandler) Middleware(h http.Handler) http.Handler {
 			// will be ignored or interpreted as a rejection.
 			// For example, the Presto engine, which is used in older versions of
 			// Opera, Opera Mobile and Opera Mini, handles CORS this way.
-			c := newContext(w, r)
+			c := handler.newContext(w, r)
 			handler.sendResp(c, HTTPResponse{
 				StatusCode: http.StatusOK,
 			})
@@ -244,7 +244,7 @@ func (handler *UnroutedHandler) Middleware(h http.Handler) http.Handler {
 		// GET and HEAD methods are not checked since a browser may visit this URL and does
 		// not include this header. GET requests are not part of the specification.
 		if r.Method != "GET" && r.Method != "HEAD" && r.Header.Get("Tus-Resumable") != "1.0.0" && isTusV1 {
-			c := newContext(w, r)
+			c := handler.newContext(w, r)
 			handler.sendError(c, ErrUnsupportedVersion)
 			return
 		}
@@ -262,7 +262,7 @@ func (handler *UnroutedHandler) PostFile(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	c := newContext(w, r)
+	c := handler.newContext(w, r)
 
 	// Check for presence of application/offset+octet-stream. If another content
 	// type is defined, it will be ignored and treated as none was set because
@@ -429,7 +429,7 @@ func (handler *UnroutedHandler) PostFile(w http.ResponseWriter, r *http.Request)
 // PostFile creates a new file upload using the datastore after validating the
 // length and parsing the metadata.
 func (handler *UnroutedHandler) PostFileV2(w http.ResponseWriter, r *http.Request) {
-	c := newContext(w, r)
+	c := handler.newContext(w, r)
 
 	// Parse headers
 	contentType := r.Header.Get("Content-Type")
@@ -582,7 +582,7 @@ func (handler *UnroutedHandler) PostFileV2(w http.ResponseWriter, r *http.Reques
 
 // HeadFile returns the length and offset for the HEAD request
 func (handler *UnroutedHandler) HeadFile(w http.ResponseWriter, r *http.Request) {
-	c := newContext(w, r)
+	c := handler.newContext(w, r)
 
 	id, err := extractIDFromPath(r.URL.Path)
 	if err != nil {
@@ -669,7 +669,7 @@ func (handler *UnroutedHandler) HeadFile(w http.ResponseWriter, r *http.Request)
 // PatchFile adds a chunk to an upload. This operation is only allowed
 // if enough space in the upload is left.
 func (handler *UnroutedHandler) PatchFile(w http.ResponseWriter, r *http.Request) {
-	c := newContext(w, r)
+	c := handler.newContext(w, r)
 
 	isTusV1 := !handler.isResumableUploadDraftRequest(r)
 
@@ -951,7 +951,7 @@ func (handler *UnroutedHandler) finishUploadIfComplete(c *httpContext, resp HTTP
 // GetFile handles requests to download a file using a GET request. This is not
 // part of the specification.
 func (handler *UnroutedHandler) GetFile(w http.ResponseWriter, r *http.Request) {
-	c := newContext(w, r)
+	c := handler.newContext(w, r)
 
 	id, err := extractIDFromPath(r.URL.Path)
 	if err != nil {
@@ -1074,7 +1074,7 @@ func filterContentType(info FileInfo) (contentType string, contentDisposition st
 
 // DelFile terminates an upload permanently.
 func (handler *UnroutedHandler) DelFile(w http.ResponseWriter, r *http.Request) {
-	c := newContext(w, r)
+	c := handler.newContext(w, r)
 
 	// Abort the request handling if the required interface is not implemented
 	if !handler.composer.UsesTerminater {

--- a/pkg/handler/utils_test.go
+++ b/pkg/handler/utils_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -44,7 +45,8 @@ type FullLock interface {
 }
 
 type httpTest struct {
-	Name string
+	Name    string
+	Context context.Context
 
 	Method string
 	URL    string
@@ -58,7 +60,11 @@ type httpTest struct {
 }
 
 func (test *httpTest) Run(handler http.Handler, t *testing.T) *httptest.ResponseRecorder {
-	req, _ := http.NewRequest(test.Method, test.URL, test.ReqBody)
+	if test.Context == nil {
+		test.Context = context.Background()
+	}
+
+	req, _ := http.NewRequestWithContext(test.Context, test.Method, test.URL, test.ReqBody)
 	req.RequestURI = test.URL
 
 	// Add headers


### PR DESCRIPTION
Closes #713, https://github.com/tus/tusd/issues/443, https://github.com/tus/tusd/pull/455, https://github.com/tus/tusd/pull/315, https://github.com/tus/tusd/pull/740, https://github.com/tus/tusd/pull/342

Hooks and data stores are given access to the request context, but in a slightly modified way:

```
	// Context provides access to the context from the HTTP request. This context is
	// not the exact value as the request context from http.Request.Context() but
	// a similar context that retains the same values as the request context. In
	// addition, Context will be cancelled after a short delay when the request context
	// is done. This delay is controlled by Config.GracefulRequestCompletionDuration.
	//
	// The reason is that we want stores to be able to continue processing a request after
	// its context has been cancelled. For example, assume a PATCH request is incoming. If
	// the end-user pauses the upload, the connection is closed causing the request context
	// to be cancelled immediately. However, we want the store to be able to save the last
	// few bytes that were transmitted before the request was aborted. To allow this, we
	// copy the request context but cancel it with a brief delay to give the data store
	// time to finish its operations.
```