### PR TITLE
feat: Allow users to set json log output

### DIFF
--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -65,6 +65,7 @@ var Flags struct {
 	PprofMutexProfileRate            int
 	BehindProxy                      bool
 	VerboseOutput                    bool
+	LogFormat                        string
 	S3TransferAcceleration           bool
 	TLSCertFile                      string
 	TLSKeyFile                       string
@@ -178,6 +179,7 @@ func ParseFlags() {
 		f.BoolVar(&Flags.ShowGreeting, "show-greeting", true, "Show the greeting message")
 		f.BoolVar(&Flags.ShowVersion, "version", false, "Print tusd version information")
 		f.BoolVar(&Flags.VerboseOutput, "verbose", true, "Enable verbose logging output")
+		f.StringVar(&Flags.LogFormat, "log-format", "text", "Logging format (txt or json)")
 	})
 
 	fs.AddGroup("Timeout options", func(f *flag.FlagSet) {


### PR DESCRIPTION
Add `-format=json` options to allow logging in json format.

```
{"time":"2023-11-04T11:17:26.702372+01:00","level":"INFO","msg":"Using '/workdir/tusd/data' as directory storage."}
{"time":"2023-11-04T11:17:26.702557+01:00","level":"INFO","msg":"Using 0.00MB as maximum size."}
{"time":"2023-11-04T11:17:26.702594+01:00","level":"INFO","msg":"Supported tus extensions: creation,creation-with-upload,termination,concatenation,creation-defer-length"}
{"time":"2023-11-04T11:17:26.7026+01:00","level":"INFO","msg":"Using 0.0.0.0:8080 as address to listen."}
{"time":"2023-11-04T11:17:26.702603+01:00","level":"INFO","msg":"Using /files/ as the base path."}
{"time":"2023-11-04T11:17:26.702631+01:00","level":"INFO","msg":"Using /metrics as the metrics path."}
{"time":"2023-11-04T11:17:26.702947+01:00","level":"INFO","msg":"You can now upload files to: http://[::]:8080/files/"}
```