### PR TITLE
Update to RUFH draft 02

### DIFF
--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -135,9 +135,9 @@ var DefaultCorsConfig = CorsConfig{
 	AllowOrigin:      regexp.MustCompile(".*"),
 	AllowCredentials: false,
 	AllowMethods:     "POST, HEAD, PATCH, OPTIONS, GET, DELETE",
-	AllowHeaders:     "Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Incomplete, Upload-Draft-Interop-Version",
+	AllowHeaders:     "Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Complete, Upload-Draft-Interop-Version",
 	MaxAge:           "86400",
-	ExposeHeaders:    "Upload-Offset, Location, Upload-Length, Tus-Version, Tus-Resumable, Tus-Max-Size, Tus-Extension, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Incomplete, Upload-Draft-Interop-Version",
+	ExposeHeaders:    "Upload-Offset, Location, Upload-Length, Tus-Version, Tus-Resumable, Tus-Max-Size, Tus-Extension, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Complete, Upload-Draft-Interop-Version",
 }
 
 func (config *Config) validate() error {

--- a/pkg/handler/cors_test.go
+++ b/pkg/handler/cors_test.go
@@ -23,7 +23,7 @@ func TestCORS(t *testing.T) {
 			},
 			Code: http.StatusOK,
 			ResHeader: map[string]string{
-				"Access-Control-Allow-Headers":     "Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Incomplete, Upload-Draft-Interop-Version",
+				"Access-Control-Allow-Headers":     "Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Complete, Upload-Draft-Interop-Version",
 				"Access-Control-Allow-Methods":     "POST, HEAD, PATCH, OPTIONS, GET, DELETE",
 				"Access-Control-Max-Age":           "86400",
 				"Access-Control-Allow-Origin":      "https://tus.io",
@@ -40,7 +40,7 @@ func TestCORS(t *testing.T) {
 			},
 			ResHeader: map[string]string{
 				"Access-Control-Allow-Origin":      "https://tus.io",
-				"Access-Control-Expose-Headers":    "Upload-Offset, Location, Upload-Length, Tus-Version, Tus-Resumable, Tus-Max-Size, Tus-Extension, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Incomplete, Upload-Draft-Interop-Version",
+				"Access-Control-Expose-Headers":    "Upload-Offset, Location, Upload-Length, Tus-Version, Tus-Resumable, Tus-Max-Size, Tus-Extension, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Complete, Upload-Draft-Interop-Version",
 				"Vary":                             "Origin",
 				"Access-Control-Allow-Methods":     "",
 				"Access-Control-Allow-Headers":     "",
@@ -72,7 +72,7 @@ func TestCORS(t *testing.T) {
 			},
 			Code: http.StatusOK,
 			ResHeader: map[string]string{
-				"Access-Control-Allow-Headers":     "Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Incomplete, Upload-Draft-Interop-Version",
+				"Access-Control-Allow-Headers":     "Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Complete, Upload-Draft-Interop-Version",
 				"Access-Control-Allow-Methods":     "POST, HEAD, PATCH, OPTIONS, GET, DELETE",
 				"Access-Control-Max-Age":           "86400",
 				"Access-Control-Allow-Origin":      "http://tus.io",
@@ -89,7 +89,7 @@ func TestCORS(t *testing.T) {
 			},
 			ResHeader: map[string]string{
 				"Access-Control-Allow-Origin":      "http://tus.io",
-				"Access-Control-Expose-Headers":    "Upload-Offset, Location, Upload-Length, Tus-Version, Tus-Resumable, Tus-Max-Size, Tus-Extension, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Incomplete, Upload-Draft-Interop-Version",
+				"Access-Control-Expose-Headers":    "Upload-Offset, Location, Upload-Length, Tus-Version, Tus-Resumable, Tus-Max-Size, Tus-Extension, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Complete, Upload-Draft-Interop-Version",
 				"Vary":                             "Origin",
 				"Access-Control-Allow-Methods":     "",
 				"Access-Control-Allow-Headers":     "",

--- a/pkg/handler/head_test.go
+++ b/pkg/handler/head_test.go
@@ -168,11 +168,11 @@ func TestHead(t *testing.T) {
 				Method: "HEAD",
 				URL:    "yes",
 				ReqHeader: map[string]string{
-					"Upload-Draft-Interop-Version": "3",
+					"Upload-Draft-Interop-Version": "4",
 				},
 				Code: http.StatusNoContent,
 				ResHeader: map[string]string{
-					"Upload-Draft-Interop-Version": "3",
+					"Upload-Draft-Interop-Version": "4",
 					"Upload-Complete":              "?0",
 					"Upload-Offset":                "5",
 				},
@@ -202,11 +202,11 @@ func TestHead(t *testing.T) {
 				Method: "HEAD",
 				URL:    "yes",
 				ReqHeader: map[string]string{
-					"Upload-Draft-Interop-Version": "3",
+					"Upload-Draft-Interop-Version": "4",
 				},
 				Code: http.StatusNoContent,
 				ResHeader: map[string]string{
-					"Upload-Draft-Interop-Version": "3",
+					"Upload-Draft-Interop-Version": "4",
 					"Upload-Complete":              "?1",
 					"Upload-Offset":                "10",
 				},
@@ -235,11 +235,11 @@ func TestHead(t *testing.T) {
 				Method: "HEAD",
 				URL:    "yes",
 				ReqHeader: map[string]string{
-					"Upload-Draft-Interop-Version": "3",
+					"Upload-Draft-Interop-Version": "4",
 				},
 				Code: http.StatusNoContent,
 				ResHeader: map[string]string{
-					"Upload-Draft-Interop-Version": "3",
+					"Upload-Draft-Interop-Version": "4",
 					"Upload-Complete":              "?0",
 					"Upload-Offset":                "5",
 				},

--- a/pkg/handler/head_test.go
+++ b/pkg/handler/head_test.go
@@ -173,7 +173,7 @@ func TestHead(t *testing.T) {
 				Code: http.StatusNoContent,
 				ResHeader: map[string]string{
 					"Upload-Draft-Interop-Version": "3",
-					"Upload-Incomplete":            "?1",
+					"Upload-Complete":              "?0",
 					"Upload-Offset":                "5",
 				},
 			}).Run(handler, t)
@@ -207,7 +207,7 @@ func TestHead(t *testing.T) {
 				Code: http.StatusNoContent,
 				ResHeader: map[string]string{
 					"Upload-Draft-Interop-Version": "3",
-					"Upload-Incomplete":            "?0",
+					"Upload-Complete":              "?1",
 					"Upload-Offset":                "10",
 				},
 			}).Run(handler, t)
@@ -240,7 +240,7 @@ func TestHead(t *testing.T) {
 				Code: http.StatusNoContent,
 				ResHeader: map[string]string{
 					"Upload-Draft-Interop-Version": "3",
-					"Upload-Incomplete":            "?1",
+					"Upload-Complete":              "?0",
 					"Upload-Offset":                "5",
 				},
 			}).Run(handler, t)

--- a/pkg/handler/patch_test.go
+++ b/pkg/handler/patch_test.go
@@ -839,7 +839,7 @@ func TestPatch(t *testing.T) {
 				ReqHeader: map[string]string{
 					"Upload-Draft-Interop-Version": "3",
 					"Upload-Offset":                "5",
-					"Upload-Incomplete":            "?0",
+					"Upload-Complete":              "?1",
 				},
 				ReqBody: strings.NewReader("hello"),
 				Code:    http.StatusNoContent,
@@ -884,7 +884,7 @@ func TestPatch(t *testing.T) {
 				ReqHeader: map[string]string{
 					"Upload-Draft-Interop-Version": "3",
 					"Upload-Offset":                "5",
-					"Upload-Incomplete":            "?0",
+					"Upload-Complete":              "?1",
 				},
 				ReqBody: strings.NewReader("hello"),
 				Code:    http.StatusNoContent,
@@ -920,7 +920,7 @@ func TestPatch(t *testing.T) {
 				ReqHeader: map[string]string{
 					"Upload-Draft-Interop-Version": "3",
 					"Upload-Offset":                "5",
-					"Upload-Incomplete":            "?1",
+					"Upload-Complete":              "?0",
 				},
 				ReqBody: strings.NewReader("hel"),
 				Code:    http.StatusNoContent,
@@ -956,7 +956,7 @@ func TestPatch(t *testing.T) {
 				ReqHeader: map[string]string{
 					"Upload-Draft-Interop-Version": "3",
 					"Upload-Offset":                "5",
-					"Upload-Incomplete":            "?1",
+					"Upload-Complete":              "?0",
 				},
 				ReqBody: strings.NewReader("hel"),
 				Code:    http.StatusNoContent,

--- a/pkg/handler/patch_test.go
+++ b/pkg/handler/patch_test.go
@@ -837,7 +837,7 @@ func TestPatch(t *testing.T) {
 				Method: "PATCH",
 				URL:    "yes",
 				ReqHeader: map[string]string{
-					"Upload-Draft-Interop-Version": "3",
+					"Upload-Draft-Interop-Version": "4",
 					"Upload-Offset":                "5",
 					"Upload-Complete":              "?1",
 				},
@@ -882,7 +882,7 @@ func TestPatch(t *testing.T) {
 				Method: "PATCH",
 				URL:    "yes",
 				ReqHeader: map[string]string{
-					"Upload-Draft-Interop-Version": "3",
+					"Upload-Draft-Interop-Version": "4",
 					"Upload-Offset":                "5",
 					"Upload-Complete":              "?1",
 				},
@@ -918,7 +918,7 @@ func TestPatch(t *testing.T) {
 				Method: "PATCH",
 				URL:    "yes",
 				ReqHeader: map[string]string{
-					"Upload-Draft-Interop-Version": "3",
+					"Upload-Draft-Interop-Version": "4",
 					"Upload-Offset":                "5",
 					"Upload-Complete":              "?0",
 				},
@@ -954,7 +954,7 @@ func TestPatch(t *testing.T) {
 				Method: "PATCH",
 				URL:    "yes",
 				ReqHeader: map[string]string{
-					"Upload-Draft-Interop-Version": "3",
+					"Upload-Draft-Interop-Version": "4",
 					"Upload-Offset":                "5",
 					"Upload-Complete":              "?0",
 				},

--- a/pkg/handler/post_test.go
+++ b/pkg/handler/post_test.go
@@ -592,7 +592,7 @@ func TestPost(t *testing.T) {
 				Method: "POST",
 				ReqHeader: map[string]string{
 					"Upload-Draft-Interop-Version": "3",
-					"Upload-Incomplete":            "?0",
+					"Upload-Complete":              "?1",
 					"Content-Type":                 "text/plain; charset=utf-8",
 					"Content-Disposition":          "attachment; filename=hello.txt",
 				},
@@ -655,7 +655,7 @@ func TestPost(t *testing.T) {
 				Method: "POST",
 				ReqHeader: map[string]string{
 					"Upload-Draft-Interop-Version": "3",
-					"Upload-Incomplete":            "?1",
+					"Upload-Complete":              "?0",
 				},
 				ReqBody: strings.NewReader("hello world"),
 				Code:    http.StatusCreated,

--- a/pkg/handler/post_test.go
+++ b/pkg/handler/post_test.go
@@ -591,7 +591,7 @@ func TestPost(t *testing.T) {
 			res := (&httpTest{
 				Method: "POST",
 				ReqHeader: map[string]string{
-					"Upload-Draft-Interop-Version": "3",
+					"Upload-Draft-Interop-Version": "4",
 					"Upload-Complete":              "?1",
 					"Content-Type":                 "text/plain; charset=utf-8",
 					"Content-Disposition":          "attachment; filename=hello.txt",
@@ -599,7 +599,7 @@ func TestPost(t *testing.T) {
 				ReqBody: strings.NewReader("hello world"),
 				Code:    http.StatusCreated,
 				ResHeader: map[string]string{
-					"Upload-Draft-Interop-Version": "3",
+					"Upload-Draft-Interop-Version": "4",
 					"Location":                     "http://tus.io/files/foo",
 					"Upload-Offset":                "11",
 				},
@@ -610,7 +610,7 @@ func TestPost(t *testing.T) {
 				{
 					Code: 104,
 					Header: http.Header{
-						"Upload-Draft-Interop-Version": []string{"3"},
+						"Upload-Draft-Interop-Version": []string{"4"},
 						"Location":                     []string{"http://tus.io/files/foo"},
 						"X-Content-Type-Options":       []string{"nosniff"},
 					},
@@ -654,13 +654,13 @@ func TestPost(t *testing.T) {
 			res := (&httpTest{
 				Method: "POST",
 				ReqHeader: map[string]string{
-					"Upload-Draft-Interop-Version": "3",
+					"Upload-Draft-Interop-Version": "4",
 					"Upload-Complete":              "?0",
 				},
 				ReqBody: strings.NewReader("hello world"),
 				Code:    http.StatusCreated,
 				ResHeader: map[string]string{
-					"Upload-Draft-Interop-Version": "3",
+					"Upload-Draft-Interop-Version": "4",
 					"Location":                     "http://tus.io/files/foo",
 					"Upload-Offset":                "11",
 				},
@@ -671,7 +671,7 @@ func TestPost(t *testing.T) {
 				{
 					Code: 104,
 					Header: http.Header{
-						"Upload-Draft-Interop-Version": []string{"3"},
+						"Upload-Draft-Interop-Version": []string{"4"},
 						"Location":                     []string{"http://tus.io/files/foo"},
 						"X-Content-Type-Options":       []string{"nosniff"},
 					},

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -17,7 +17,7 @@ import (
 )
 
 const UploadLengthDeferred = "1"
-const currentUploadDraftInteropVersion = "3"
+const currentUploadDraftInteropVersion = "4"
 
 var (
 	reExtractFileID  = regexp.MustCompile(`([^/]+)\/?$`)

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -434,7 +434,7 @@ func (handler *UnroutedHandler) PostFileV2(w http.ResponseWriter, r *http.Reques
 	// Parse headers
 	contentType := r.Header.Get("Content-Type")
 	contentDisposition := r.Header.Get("Content-Disposition")
-	isComplete := r.Header.Get("Upload-Incomplete") == "?0"
+	isComplete := r.Header.Get("Upload-Complete") == "?1"
 
 	info := FileInfo{
 		MetaData: make(MetaData),
@@ -652,9 +652,9 @@ func (handler *UnroutedHandler) HeadFile(w http.ResponseWriter, r *http.Request)
 	} else {
 		if !info.SizeIsDeferred && info.Offset == info.Size {
 			// Upload is complete if we know the size and it matches the offset.
-			resp.Header["Upload-Incomplete"] = "?0"
+			resp.Header["Upload-Complete"] = "?1"
 		} else {
-			resp.Header["Upload-Incomplete"] = "?1"
+			resp.Header["Upload-Complete"] = "?0"
 		}
 
 		resp.Header["Upload-Draft-Interop-Version"] = currentUploadDraftInteropVersion
@@ -726,7 +726,7 @@ func (handler *UnroutedHandler) PatchFile(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// TODO: If Upload-Incomplete: ?0 and Content-Length is set, we can
+	// TODO: If Upload-Complete: ?1 and Content-Length is set, we can
 	// - declare the length already here
 	// - validate that the length from this request matches info.Size if !info.SizeIsDeferred
 
@@ -773,7 +773,7 @@ func (handler *UnroutedHandler) PatchFile(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	isComplete := r.Header.Get("Upload-Incomplete") == "?0"
+	isComplete := r.Header.Get("Upload-Complete") == "?1"
 	if isComplete && info.SizeIsDeferred {
 		info, err = upload.GetInfo(c)
 		if err != nil {


### PR DESCRIPTION
There are two breaking changes that we need to incorporate: Upload-Complete and the new interop version. See https://www.ietf.org/archive/id/draft-ietf-httpbis-resumable-upload-02.html#name-since-draft-ietf-httpbis-re