### PR TITLE
handler: support range requests for GET /upload

### DIFF
--- a/pkg/handler/get_test.go
+++ b/pkg/handler/get_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+
 	. "github.com/tus/tusd/v2/pkg/handler"
 )
 
@@ -163,5 +164,61 @@ func TestGet(t *testing.T) {
 			Code:    http.StatusNoContent,
 			ResBody: "",
 		}).Run(handler, t)
+	})
+
+	SubTest(t, "RangeRequest", func(t *testing.T, store *MockFullDataStore, _ *StoreComposer) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		upload := NewMockFullUpload(ctrl)
+		locker := NewMockFullLocker(ctrl)
+		lock := NewMockFullLock(ctrl)
+
+		reader := &closingStringReader{
+			Reader: strings.NewReader("hello"),
+		}
+
+		gomock.InOrder(
+			locker.EXPECT().NewLock("yes").Return(lock, nil),
+			lock.EXPECT().Lock(gomock.Any(), gomock.Any()).Return(nil),
+			store.EXPECT().GetUpload(gomock.Any(), "yes").Return(upload, nil),
+			upload.EXPECT().GetInfo(gomock.Any()).Return(FileInfo{
+				Offset: 5,
+				Size:   20,
+				MetaData: map[string]string{
+					"filename": "file.jpg\"evil",
+					"filetype": "image/jpeg",
+				},
+				IsFinal: true,
+			}, nil),
+			upload.EXPECT().GetReader(gomock.Any()).Return(reader, nil),
+			lock.EXPECT().Unlock().Return(nil),
+		)
+
+		composer := NewStoreComposer()
+		composer.UseCore(store)
+		composer.UseLocker(locker)
+
+		handler, _ := NewHandler(Config{
+			StoreComposer: composer,
+		})
+
+		(&httpTest{
+			Method: "GET",
+			URL:    "yes",
+			ReqHeader: map[string]string{
+				"Range": "bytes=0-3",
+			},
+			ResHeader: map[string]string{
+				"Content-Length":      "4",
+				"Content-Type":        "image/jpeg",
+				"Content-Disposition": `inline;filename="file.jpg\"evil"`,
+			},
+			Code:    http.StatusOK,
+			ResBody: "hell",
+		}).Run(handler, t)
+
+		if !reader.closed {
+			t.Error("expected reader to be closed")
+		}
 	})
 }

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -646,6 +646,7 @@ func (handler *UnroutedHandler) HeadFile(w http.ResponseWriter, r *http.Request)
 		} else {
 			resp.Header["Upload-Length"] = strconv.FormatInt(info.Size, 10)
 			resp.Header["Content-Length"] = strconv.FormatInt(info.Size, 10)
+			resp.Header["Accept-Ranges"] = "bytes"
 		}
 
 		resp.StatusCode = http.StatusOK
@@ -999,6 +1000,13 @@ func (handler *UnroutedHandler) GetFile(w http.ResponseWriter, r *http.Request) 
 	src, err := upload.GetReader(c)
 	if err != nil {
 		handler.sendError(c, err)
+		return
+	}
+
+	if seeker, ok := src.(io.ReadSeeker); ok {
+		handler.sendResp(c, resp)
+		http.ServeContent(w, r, info.ID, time.Time{}, seeker)
+		_ = src.Close()
 		return
 	}
 


### PR DESCRIPTION
Where the store supports it, use [`http.ServeContent`](https://pkg.go.dev/net/http#ServeContent) to serve the contents of the upload, thereby adding support for range requests:

> The main benefit of ServeContent over io.Copy is that it handles Range requests properly, sets the MIME type, and handles If-Match, If-Unmodified-Since, If-None-Match, If-Modified-Since, and If-Range requests.

This helps optimise downloading large files directly from tusd.