### PR TITLE
s3store: Fix downloads from some S3-compatible stores

### DIFF
--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -694,7 +694,9 @@ func (upload s3Upload) fetchInfo(ctx context.Context) (info handler.FileInfo, pa
 		// The AWS Go SDK v2 has a bug where types.NoSuchUpload is not returned,
 		// so we also need to check the error code itself.
 		// See https://github.com/aws/aws-sdk-go-v2/issues/1635
-		if isAwsError[*types.NoSuchUpload](err) || isAwsErrorCode(err, "NoSuchUpload") || isAwsError[*types.NoSuchKey](err) {
+		// In addition, S3-compatible storages, like DigitalOcean Spaces, might cause
+		// types.NoSuchKey to not be returned as well.
+		if isAwsError[*types.NoSuchUpload](err) || isAwsErrorCode(err, "NoSuchUpload") || isAwsError[*types.NoSuchKey](err) || isAwsErrorCode(err, "NoSuchKey") {
 			info.Offset = info.Size
 			err = nil
 		}


### PR DESCRIPTION
When downloading a completed upload via a GET request from DigitalOcean Spaces, an error would be returned because the corresponding multipart uploads was (as expected) not found. This PR patches the error handling to correctly ignore this error.

Fixes an error discovered in https://github.com/tus/tusd/issues/1067#issuecomment-1907924262.
See https://github.com/tus/tusd/issues/1015 for similar errors in the past.