### PR TITLE
hooks: add pre-resume blocking hook

### DIFF
--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -69,6 +69,11 @@ type Config struct {
 	// that should be overwriten before the upload is create. See its type definition for
 	// more details on its behavior. If you do not want to make any changes, return an empty struct.
 	PreUploadCreateCallback func(hook HookEvent) (HTTPResponse, FileInfoChanges, error)
+	// PreUploadResumeCallback will be invoked before resuming an upload, if the
+	// property is supplied. If the callback returns no error, the upload will continue.
+	// If the error is non-nil, the upload will be rejected. This can be used to implement
+	// authorization.
+	PreUploadResumeCallback func(hook HookEvent) error
 	// PreFinishResponseCallback will be invoked after an upload is completed but before
 	// a response is returned to the client. This can be used to implement post-processing validation.
 	// If the callback returns no error, optional values from HTTPResponse will be contained in the HTTP response.

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -749,6 +749,14 @@ func (handler *UnroutedHandler) PatchFile(w http.ResponseWriter, r *http.Request
 		Header:     make(HTTPHeader, 1), // Initialize map, so writeChunk can set the Upload-Offset header.
 	}
 
+	if handler.config.PreUploadResumeCallback != nil {
+		err := handler.config.PreUploadResumeCallback(newHookEvent(c, info))
+		if err != nil {
+			handler.sendError(c, err)
+			return
+		}
+	}
+
 	// Do not proxy the call to the data store if the upload is already completed
 	if !info.SizeIsDeferred && info.Offset == info.Size {
 		resp.Header["Upload-Offset"] = strconv.FormatInt(offset, 10)


### PR DESCRIPTION
`pre-resume` blocking hook, inspired by `pre-create` and `pre-finish` hooks. Disable by default.

Called on patch request to continue an existing upload. Upload can be rejected with `RejectUpload` and if so `HTTPResponse` is used in error http response. Otherwise response is ignored.

Useful for authentication/authorization of PATCH requests, as evoked in https://github.com/tus/tusd/issues/669#issuecomment-1051924886
