### PR TITLE
Add IncludeInfoObject flag for terminating the .info in gcs as well

### DIFF
--- a/pkg/gcsstore/gcsservice.go
+++ b/pkg/gcsstore/gcsservice.go
@@ -43,6 +43,9 @@ type GCSFilterParams struct {
 
 	// Prefix specifies the prefix of which you want to filter object names with.
 	Prefix string
+
+	// IncludeInfoObject indicates whether to include or ignore the info object.
+	IncludeInfoObject bool
 }
 
 // GCSReader implements cloud.google.com/go/storage.Reader.
@@ -202,8 +205,9 @@ func (service *GCSService) recursiveCompose(ctx context.Context, srcs []string, 
 		// Remove all the temporary composition objects
 		prefix := fmt.Sprintf("%s_tmp", params.Destination)
 		filterParams := GCSFilterParams{
-			Bucket: params.Bucket,
-			Prefix: prefix,
+			Bucket:            params.Bucket,
+			Prefix:            prefix,
+			IncludeInfoObject: false,
 		}
 
 		err = service.DeleteObjectsWithFilter(ctx, filterParams)
@@ -352,7 +356,7 @@ loop:
 			return nil, err
 		}
 
-		if strings.HasSuffix(objAttrs.Name, "info") {
+		if !params.IncludeInfoObject && strings.HasSuffix(objAttrs.Name, "info") {
 			continue
 		}
 

--- a/pkg/gcsstore/gcsservice_test.go
+++ b/pkg/gcsstore/gcsservice_test.go
@@ -99,8 +99,9 @@ func TestDeleteObjectWithFilter(t *testing.T) {
 	}
 
 	err = service.DeleteObjectsWithFilter(ctx, GCSFilterParams{
-		Bucket: "test-bucket",
-		Prefix: "test-prefix",
+		Bucket:            "test-bucket",
+		Prefix:            "test-prefix",
+		IncludeInfoObject: true,
 	})
 
 	if err != nil {
@@ -510,8 +511,9 @@ func TestFilterObject(t *testing.T) {
 	}
 
 	objects, err := service.FilterObjects(ctx, GCSFilterParams{
-		Bucket: "test-bucket",
-		Prefix: "test-prefix",
+		Bucket:            "test-bucket",
+		Prefix:            "test-prefix",
+		IncludeInfoObject: false,
 	})
 
 	if err != nil {

--- a/pkg/gcsstore/gcsstore.go
+++ b/pkg/gcsstore/gcsstore.go
@@ -94,8 +94,9 @@ func (upload gcsUpload) WriteChunk(ctx context.Context, offset int64, src io.Rea
 
 	prefix := fmt.Sprintf("%s_", store.keyWithPrefix(id))
 	filterParams := GCSFilterParams{
-		Bucket: store.Bucket,
-		Prefix: prefix,
+		Bucket:            store.Bucket,
+		Prefix:            prefix,
+		IncludeInfoObject: false,
 	}
 
 	names, err := store.Service.FilterObjects(ctx, filterParams)
@@ -165,8 +166,9 @@ func (upload gcsUpload) GetInfo(ctx context.Context) (handler.FileInfo, error) {
 
 	prefix := store.keyWithPrefix(id)
 	filterParams := GCSFilterParams{
-		Bucket: store.Bucket,
-		Prefix: prefix,
+		Bucket:            store.Bucket,
+		Prefix:            prefix,
+		IncludeInfoObject: false,
 	}
 
 	names, err := store.Service.FilterObjects(ctx, filterParams)
@@ -261,8 +263,9 @@ func (upload gcsUpload) FinishUpload(ctx context.Context) error {
 
 	prefix := fmt.Sprintf("%s_", store.keyWithPrefix(id))
 	filterParams := GCSFilterParams{
-		Bucket: store.Bucket,
-		Prefix: prefix,
+		Bucket:            store.Bucket,
+		Prefix:            prefix,
+		IncludeInfoObject: false,
 	}
 
 	names, err := store.Service.FilterObjects(ctx, filterParams)
@@ -313,8 +316,9 @@ func (upload gcsUpload) Terminate(ctx context.Context) error {
 	store := upload.store
 
 	filterParams := GCSFilterParams{
-		Bucket: store.Bucket,
-		Prefix: store.keyWithPrefix(id),
+		Bucket:            store.Bucket,
+		Prefix:            store.keyWithPrefix(id),
+		IncludeInfoObject: true,
 	}
 
 	err := store.Service.DeleteObjectsWithFilter(ctx, filterParams)

--- a/pkg/gcsstore/gcsstore_test.go
+++ b/pkg/gcsstore/gcsstore_test.go
@@ -145,8 +145,9 @@ func TestGetInfo(t *testing.T) {
 	r := MockGetInfoReader{}
 
 	filterParams := gcsstore.GCSFilterParams{
-		Bucket: store.Bucket,
-		Prefix: mockID,
+		Bucket:            store.Bucket,
+		Prefix:            mockID,
+		IncludeInfoObject: false,
 	}
 
 	mockObjectParams0 := gcsstore.GCSObjectParams{
@@ -288,8 +289,9 @@ func TestTerminate(t *testing.T) {
 	assert.Equal(store.Bucket, mockBucket)
 
 	filterParams := gcsstore.GCSFilterParams{
-		Bucket: store.Bucket,
-		Prefix: mockID,
+		Bucket:            store.Bucket,
+		Prefix:            mockID,
+		IncludeInfoObject: true,
 	}
 
 	ctx := context.Background()
@@ -313,13 +315,15 @@ func TestFinishUpload(t *testing.T) {
 	assert.Equal(store.Bucket, mockBucket)
 
 	filterParams := gcsstore.GCSFilterParams{
-		Bucket: store.Bucket,
-		Prefix: fmt.Sprintf("%s_", mockID),
+		Bucket:            store.Bucket,
+		Prefix:            fmt.Sprintf("%s_", mockID),
+		IncludeInfoObject: false,
 	}
 
 	filterParams2 := gcsstore.GCSFilterParams{
-		Bucket: store.Bucket,
-		Prefix: mockID,
+		Bucket:            store.Bucket,
+		Prefix:            mockID,
+		IncludeInfoObject: false,
 	}
 
 	composeParams := gcsstore.GCSComposeParams{
@@ -406,8 +410,9 @@ func TestWriteChunk(t *testing.T) {
 
 	// filter objects
 	filterParams := gcsstore.GCSFilterParams{
-		Bucket: store.Bucket,
-		Prefix: fmt.Sprintf("%s_", mockID),
+		Bucket:            store.Bucket,
+		Prefix:            fmt.Sprintf("%s_", mockID),
+		IncludeInfoObject: false,
 	}
 
 	var partials = []string{mockPartial0}


### PR DESCRIPTION
*Description*
Issueing the termination process the filestore removes both the binary as well as the .info file. The gcc store only removes the binary file.

*How to solve*
A user wrote: 

> A solution would be to add an object IncludeInfoObject to GCSFilterParams, which can be set by the termination code to instruct FilterObjects to not exclude .info objects.

That's what i have done, if i understood the assessment correctly. Everywhere where the `GCSFilterParams` was declared, I included the `IncludeInfoObject` even if the default value would be false anyway. Only at the termination process, the `IncludeInfoObject` is set to `true`.

_Side note: My very first pull request, just trying to help._

Related Issue #1075 