### PR TITLE
handler: Support RUFH draft -03

### DIFF
--- a/pkg/handler/head_test.go
+++ b/pkg/handler/head_test.go
@@ -145,7 +145,7 @@ func TestHead(t *testing.T) {
 	})
 
 	SubTest(t, "ExperimentalProtocol", func(t *testing.T, _ *MockFullDataStore, _ *StoreComposer) {
-		for _, interopVersion := range []string{"3", "4"} {
+		for _, interopVersion := range []string{"3", "4", "5"} {
 			SubTest(t, "InteropVersion"+interopVersion, func(t *testing.T, _ *MockFullDataStore, _ *StoreComposer) {
 				SubTest(t, "IncompleteUpload", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
 					ctrl := gomock.NewController(t)

--- a/pkg/handler/patch_test.go
+++ b/pkg/handler/patch_test.go
@@ -811,7 +811,7 @@ func TestPatch(t *testing.T) {
 	})
 
 	SubTest(t, "ExperimentalProtocol", func(t *testing.T, _ *MockFullDataStore, _ *StoreComposer) {
-		for _, interopVersion := range []string{"3", "4"} {
+		for _, interopVersion := range []string{"3", "4", "5"} {
 			SubTest(t, "InteropVersion"+interopVersion, func(t *testing.T, _ *MockFullDataStore, _ *StoreComposer) {
 				SubTest(t, "CompleteUploadWithKnownSize", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
 					ctrl := gomock.NewController(t)

--- a/pkg/handler/post_test.go
+++ b/pkg/handler/post_test.go
@@ -546,7 +546,7 @@ func TestPost(t *testing.T) {
 	})
 
 	SubTest(t, "ExperimentalProtocol", func(t *testing.T, _ *MockFullDataStore, _ *StoreComposer) {
-		for _, interopVersion := range []string{"3", "4"} {
+		for _, interopVersion := range []string{"3", "4", "5"} {
 			SubTest(t, "InteropVersion"+interopVersion, func(t *testing.T, _ *MockFullDataStore, _ *StoreComposer) {
 				SubTest(t, "CompleteUpload", func(t *testing.T, store *MockFullDataStore, _ *StoreComposer) {
 					ctrl := gomock.NewController(t)

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -27,6 +27,7 @@ type draftVersion string
 const (
 	interopVersion3 draftVersion = "3" // From draft version -01
 	interopVersion4 draftVersion = "4" // From draft version -02
+	interopVersion5 draftVersion = "5" // From draft version -03
 )
 
 var (
@@ -678,7 +679,8 @@ func (handler *UnroutedHandler) HeadFile(w http.ResponseWriter, r *http.Request)
 		setIETFDraftUploadComplete(r, resp, isUploadCompleteNow)
 		resp.Header["Upload-Draft-Interop-Version"] = string(getIETFDraftInteropVersion(r))
 
-		// Draft requires a 204 No Content response
+		// Draft -01 and -02 require a 204 No Content response. Version -03 allows 200 OK as well,
+		// but we stick to 204 to not make the logic less complex.
 		resp.StatusCode = http.StatusNoContent
 	}
 
@@ -1364,7 +1366,7 @@ func (handler UnroutedHandler) usesIETFDraft(r *http.Request) bool {
 func getIETFDraftInteropVersion(r *http.Request) draftVersion {
 	version := draftVersion(r.Header.Get("Upload-Draft-Interop-Version"))
 	switch version {
-	case interopVersion3, interopVersion4:
+	case interopVersion3, interopVersion4, interopVersion5:
 		return version
 	default:
 		return ""
@@ -1376,7 +1378,7 @@ func getIETFDraftInteropVersion(r *http.Request) draftVersion {
 func isIETFDraftUploadComplete(r *http.Request) bool {
 	currentUploadDraftInteropVersion := getIETFDraftInteropVersion(r)
 	switch currentUploadDraftInteropVersion {
-	case interopVersion4:
+	case interopVersion4, interopVersion5:
 		return r.Header.Get("Upload-Complete") == "?1"
 	case interopVersion3:
 		return r.Header.Get("Upload-Incomplete") == "?0"
@@ -1397,7 +1399,7 @@ func setIETFDraftUploadComplete(r *http.Request, resp HTTPResponse, isComplete b
 		} else {
 			resp.Header["Upload-Incomplete"] = "?1"
 		}
-	case interopVersion4:
+	case interopVersion4, interopVersion5:
 		if isComplete {
 			resp.Header["Upload-Complete"] = "?1"
 		} else {

--- a/pkg/handler/utils_test.go
+++ b/pkg/handler/utils_test.go
@@ -142,7 +142,7 @@ func addIETFUploadCompleteHeader(header map[string]string, isComplete bool, inte
 		} else {
 			header["Upload-Incomplete"] = "?1"
 		}
-	case "4":
+	case "4", "5":
 		if isComplete {
 			header["Upload-Complete"] = "?1"
 		} else {


### PR DESCRIPTION
This PR adds support for the [new draft version](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-resumable-upload-03). It does not include major changes beside allowing a new response code for HEAD requests (which we don't use) and an increment in the interoperability version.

This PR preserves the support for earlier draft versions.