### PR TITLE
handler: Fix error with RUFH upload ending too soon

### DIFF
--- a/pkg/handler/body_reader.go
+++ b/pkg/handler/body_reader.go
@@ -74,7 +74,7 @@ func (r *bodyReader) Read(b []byte) (int, error) {
 		// All of the following errors can be understood as the input stream ending too soon:
 		// - io.ErrClosedPipe is returned in the package's unit test with io.Pipe()
 		// - io.UnexpectedEOF means that the client aborted the request.
-		if err == io.EOF || err == io.ErrClosedPipe || err == io.ErrUnexpectedEOF {
+		if err == io.ErrClosedPipe || err == io.ErrUnexpectedEOF {
 			err = ErrUnexpectedEOF
 		}
 

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -62,6 +62,7 @@ var (
 	ErrUploadInterrupted                = NewError("ERR_UPLOAD_INTERRUPTED", "upload has been interrupted by another request for this upload resource", http.StatusBadRequest)
 	ErrServerShutdown                   = NewError("ERR_SERVER_SHUTDOWN", "request has been interrupted because the server is shutting down", http.StatusServiceUnavailable)
 	ErrOriginNotAllowed                 = NewError("ERR_ORIGIN_NOT_ALLOWED", "request origin is not allowed", http.StatusForbidden)
+	ErrUnexpectedEOF                    = NewError("ERR_UNEXPECTED_EOF", "server expected to receive more bytes", http.StatusBadRequest)
 
 	// These two responses are 500 for backwards compatability. Clients might receive a timeout response
 	// when the upload got interrupted. Most clients will not retry 4XX but only 5XX, so we responsd with 500 here.


### PR DESCRIPTION
Currently, if a RUFH PATCH requests gets interrupted, the error is swallowed by the bodyReader. This is not a problem for tus uploads, but leads to issues with RUFH uploads because a successful RUFH PATCH request with Upload-Complete: ?1 will set the upload length. If an interrupted PATCH is thus interpreted as successful, it will cause the upload length to be set to the offset at which the upload was interrupted and thus preventing the upload from being resumed.

This PR fixes this problem by not swallowing the error, making the handler aware of the interruption.