### PR TITLE
Handle slash trimmed path in example server

### DIFF
--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -51,6 +51,7 @@ func main() {
 	// our own. In the end, tusd will start listening on and accept request at
 	// http://localhost:8080/files
 	http.Handle("/files/", http.StripPrefix("/files/", handler))
+	http.Handle("/files", http.StripPrefix("/files", handler))
 	err = http.ListenAndServe(":8080", nil)
 	if err != nil {
 		panic(fmt.Errorf("unable to listen: %s", err))


### PR DESCRIPTION
The tusd handler works on slash trimmed paths i.e `/files`. Making the example server do the same.

**Usecase:**
Just wasted a couple of hours debugging this behaviour using the example server.