### PR TITLE
Fix graceful terminate in filestore.

### DIFF
--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -24,10 +24,8 @@ import (
 	"github.com/tus/tusd/v2/pkg/handler"
 )
 
-var (
-	defaultFilePerm      = os.FileMode(0664)
-	defaultDirectoryPerm = os.FileMode(0754)
-)
+var defaultFilePerm = os.FileMode(0664)
+var defaultDirectoryPerm = os.FileMode(0754)
 
 // See the handler.DataStore interface for documentation about the different
 // methods.

--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -15,6 +15,7 @@ package filestore
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -175,10 +176,16 @@ func (upload *fileUpload) Terminate(ctx context.Context) error {
 	// Account for server crashes or force kills
 	// Say if killed just after removing the bin file
 	err := os.Remove(upload.binPath)
-	if !os.IsNotExist(err) {
+	if !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	return os.Remove(upload.infoPath)
+
+	err = os.Remove(upload.infoPath)
+	if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	return nil
 }
 
 func (upload *fileUpload) ConcatUploads(ctx context.Context, uploads []handler.Upload) (err error) {

--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -24,8 +24,10 @@ import (
 	"github.com/tus/tusd/v2/pkg/handler"
 )
 
-var defaultFilePerm = os.FileMode(0664)
-var defaultDirectoryPerm = os.FileMode(0754)
+var (
+	defaultFilePerm      = os.FileMode(0664)
+	defaultDirectoryPerm = os.FileMode(0754)
+)
 
 // See the handler.DataStore interface for documentation about the different
 // methods.
@@ -172,13 +174,10 @@ func (upload *fileUpload) GetReader(ctx context.Context) (io.ReadCloser, error) 
 }
 
 func (upload *fileUpload) Terminate(ctx context.Context) error {
-	if err := os.Remove(upload.infoPath); err != nil {
-		return err
-	}
-	if err := os.Remove(upload.binPath); err != nil {
-		return err
-	}
-	return nil
+	// Ignore errors when removing bin to account for server crashes or force kills
+	// This can happen say if the server crashes just after removing the bin file
+	os.Remove(upload.binPath)
+	return os.Remove(upload.infoPath)
 }
 
 func (upload *fileUpload) ConcatUploads(ctx context.Context, uploads []handler.Upload) (err error) {

--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -174,9 +174,12 @@ func (upload *fileUpload) GetReader(ctx context.Context) (io.ReadCloser, error) 
 }
 
 func (upload *fileUpload) Terminate(ctx context.Context) error {
-	// Ignore errors when removing bin to account for server crashes or force kills
-	// This can happen say if the server crashes just after removing the bin file
-	os.Remove(upload.binPath)
+	// Account for server crashes or force kills
+	// Say if killed just after removing the bin file
+	err := os.Remove(upload.binPath)
+	if !os.IsNotExist(err) {
+		return err
+	}
 	return os.Remove(upload.infoPath)
 }
 

--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -173,8 +173,9 @@ func (upload *fileUpload) GetReader(ctx context.Context) (io.ReadCloser, error) 
 }
 
 func (upload *fileUpload) Terminate(ctx context.Context) error {
-	// Account for server crashes or force kills
-	// Say if killed just after removing the bin file
+	// We ignore errors indicating that the files cannot be found because we want
+	// to delete them anyways. The files might be removed by a cron job for cleaning up
+	// or some file might have been removed when tusd crashed during the termination.
 	err := os.Remove(upload.binPath)
 	if !errors.Is(err, os.ErrNotExist) {
 		return err


### PR DESCRIPTION
In the current logic, we first delete the bin file and then the info file. We should instead do the reverse and ignore any errors when deleting the bin file. This ensures that any disgraceful shutdown would properly recover.

*Note:* This is only fixed in the filestore for now - might need to fix for other stores as well.