### PR TITLE
s3store: Allow `+` in object IDs

### DIFF
--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -1148,7 +1148,7 @@ func (store S3Store) deleteIncompletePartForUpload(ctx context.Context, uploadId
 }
 
 func splitIds(id string) (objectId, multipartId string) {
-	index := strings.Index(id, "+")
+	index := strings.LastIndex(id, "+")
 	if index == -1 {
 		return
 	}

--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -1148,6 +1148,8 @@ func (store S3Store) deleteIncompletePartForUpload(ctx context.Context, uploadId
 }
 
 func splitIds(id string) (objectId, multipartId string) {
+	// We use LastIndex to allow plus signs in the object ID and assume that S3 will never
+	// returns multipart ID that incldues a plus sign.
 	index := strings.LastIndex(id, "+")
 	if index == -1 {
 		return


### PR DESCRIPTION
To be compatible with object id that contains `+` .