### PR TITLE
gcsstore: Fix error creating new uploads

### DIFF
--- a/pkg/gcsstore/gcsservice.go
+++ b/pkg/gcsstore/gcsservice.go
@@ -47,6 +47,7 @@ type GCSFilterParams struct {
 
 // GCSReader implements cloud.google.com/go/storage.Reader.
 // It is used to read Google Cloud storage objects.
+// TODO: Remain, Size, ContentType seem to only be used in tests. Maybe we can replace this interface with an io.ReadCloser?
 type GCSReader interface {
 	Close() error
 	ContentType() string

--- a/pkg/gcsstore/gcsstore.go
+++ b/pkg/gcsstore/gcsstore.go
@@ -152,8 +152,10 @@ func (upload gcsUpload) GetInfo(ctx context.Context) (handler.FileInfo, error) {
 		}
 		return info, err
 	}
+	defer r.Close()
 
-	buf, err := io.ReadAll(r)
+	buf := make([]byte, r.Size())
+	_, err = io.ReadFull(r, buf)
 	if err != nil {
 		return info, err
 	}

--- a/pkg/gcsstore/gcsstore.go
+++ b/pkg/gcsstore/gcsstore.go
@@ -153,8 +153,7 @@ func (upload gcsUpload) GetInfo(ctx context.Context) (handler.FileInfo, error) {
 		return info, err
 	}
 
-	buf := make([]byte, r.Size())
-	_, err = r.Read(buf)
+	buf, err := io.ReadAll(r)
 	if err != nil {
 		return info, err
 	}

--- a/pkg/gcsstore/gcsstore.go
+++ b/pkg/gcsstore/gcsstore.go
@@ -154,8 +154,7 @@ func (upload gcsUpload) GetInfo(ctx context.Context) (handler.FileInfo, error) {
 	}
 	defer r.Close()
 
-	buf := make([]byte, r.Size())
-	_, err = io.ReadFull(r, buf)
+	buf, err := io.ReadAll(r)
 	if err != nil {
 		return info, err
 	}


### PR DESCRIPTION
Change r.Read(buf) to io.ReadFull(buf) as discussed in issue #1124 to fix EOF error on .info read from GCS