### PR TITLE
filestore: add dirs(0775) and files(0644) chmod(2) perms options

### DIFF
--- a/cmd/tusd/cli/composer.go
+++ b/cmd/tusd/cli/composer.go
@@ -144,11 +144,11 @@ func CreateComposer() {
 		}
 
 		stdout.Printf("Using '%s' as directory storage.\n", dir)
-		if err := os.MkdirAll(dir, os.FileMode(0774)); err != nil {
+		if err := os.MkdirAll(dir, os.FileMode(Flags.DirPerms)); err != nil {
 			stderr.Fatalf("Unable to ensure directory exists: %s", err)
 		}
 
-		store := filestore.New(dir)
+		store := filestore.New(dir, Flags.DirPerms, Flags.FilePerms)
 		store.UseIn(Composer)
 
 		locker := filelocker.New(dir)

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"flag"
+	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -74,11 +76,36 @@ var Flags struct {
 	AcquireLockTimeout               time.Duration
 	FilelockHolderPollInterval       time.Duration
 	FilelockAcquirerPollInterval     time.Duration
+	FilePerms                        uint32
+	DirPerms                         uint32
 	GracefulRequestCompletionTimeout time.Duration
 	ExperimentalProtocol             bool
 }
 
+type ChmodPermsValue struct {
+	perms *uint32
+}
+
+func (v ChmodPermsValue) String() string {
+	if v.perms != nil {
+		return fmt.Sprintf("%o", *v.perms)
+	}
+	return ""
+}
+
+func (v ChmodPermsValue) Set(s string) error {
+	if u, err := strconv.ParseUint(s, 8, 32); err != nil {
+		return err
+	} else {
+		*v.perms = uint32(u)
+	}
+	return nil
+}
+
 func ParseFlags() {
+	Flags.DirPerms = 0775
+	Flags.FilePerms = 0664
+
 	fs := grouped_flags.NewFlagGroupSet(flag.ExitOnError)
 
 	fs.AddGroup("Listening options", func(f *flag.FlagSet) {
@@ -116,6 +143,8 @@ func ParseFlags() {
 		f.StringVar(&Flags.UploadDir, "upload-dir", "./data", "Directory to store uploads in")
 		f.DurationVar(&Flags.FilelockHolderPollInterval, "filelock-holder-poll-interval", 5*time.Second, "The holder of a lock polls regularly to see if another request handler needs the lock. This flag specifies the poll interval.")
 		f.DurationVar(&Flags.FilelockAcquirerPollInterval, "filelock-acquirer-poll-interval", 2*time.Second, "The acquirer of a lock polls regularly to see if the lock has been released. This flag specifies the poll interval.")
+		f.Var(&ChmodPermsValue{&Flags.DirPerms}, "dir-perms", "The created directory chmod(2) OCTAL value permissions.")
+		f.Var(&ChmodPermsValue{&Flags.FilePerms}, "file-perms", "The created file chmod(2) OCTAL value permissions.")
 	})
 
 	fs.AddGroup("AWS S3 storage options", func(f *flag.FlagSet) {

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,4 +6,8 @@ set -o pipefail
 
 . /usr/local/share/load-env.sh
 
+if [ -n "$UMASK" ]; then
+   umask "$UMASK"
+fi
+
 exec tusd "$@"

--- a/docs/_advanced-topics/usage-package.md
+++ b/docs/_advanced-topics/usage-package.md
@@ -27,7 +27,7 @@ func main() {
 	// If you want to save them on a different medium, for example
 	// a remote FTP server, you can implement your own storage backend
 	// by implementing the tusd.DataStore interface.
-	store := filestore.New("./uploads")
+	store := filestore.New("./uploads", 0774, 0664)
 
 	// A locking mechanism helps preventing data loss or corruption from
 	// parallel requests to a upload resource. A good match for the disk-based

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -16,7 +16,7 @@ func main() {
 	// If you want to save them on a different medium, for example
 	// a remote FTP server, you can implement your own storage backend
 	// by implementing the tusd.DataStore interface.
-	store := filestore.New("./uploads")
+	store := filestore.New("./uploads", 0774, 0664)
 
 	// A locking mechanism helps preventing data loss or corruption from
 	// parallel requests to a upload resource. A good match for the disk-based

--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -25,22 +26,22 @@ import (
 	"github.com/tus/tusd/v2/pkg/handler"
 )
 
-var defaultFilePerm = os.FileMode(0664)
-var defaultDirectoryPerm = os.FileMode(0754)
-
 // See the handler.DataStore interface for documentation about the different
 // methods.
 type FileStore struct {
 	// Relative or absolute path to store files in. FileStore does not check
 	// whether the path exists, use os.MkdirAll in this case on your own.
 	Path string
+
+	DirPerm  fs.FileMode
+	FilePerm fs.FileMode
 }
 
 // New creates a new file based storage backend. The directory specified will
 // be used as the only storage entry. This method does not check
 // whether the path exists, use os.MkdirAll to ensure.
-func New(path string) FileStore {
-	return FileStore{path}
+func New(path string, dirPerms uint32, filePerms uint32) FileStore {
+	return FileStore{path, os.FileMode(dirPerms), os.FileMode(filePerms)}
 }
 
 // UseIn sets this store as the core data store in the passed composer and adds
@@ -73,7 +74,7 @@ func (store FileStore) NewUpload(ctx context.Context, info handler.FileInfo) (ha
 	}
 
 	// Create binary file with no content
-	if err := createFile(binPath, nil); err != nil {
+	if err := createFile(binPath, store.DirPerm, store.FilePerm, nil); err != nil {
 		return nil, err
 	}
 
@@ -81,6 +82,8 @@ func (store FileStore) NewUpload(ctx context.Context, info handler.FileInfo) (ha
 		info:     info,
 		infoPath: infoPath,
 		binPath:  binPath,
+		dirPerm:  store.DirPerm,
+		filePerm: store.FilePerm,
 	}
 
 	// writeInfo creates the file by itself if necessary
@@ -133,6 +136,8 @@ func (store FileStore) GetUpload(ctx context.Context, id string) (handler.Upload
 		info:     info,
 		binPath:  binPath,
 		infoPath: infoPath,
+		dirPerm:  store.DirPerm,
+		filePerm: store.FilePerm,
 	}, nil
 }
 
@@ -166,6 +171,9 @@ type fileUpload struct {
 	infoPath string
 	// binPath is the path to the binary file (which has no extension)
 	binPath string
+
+	dirPerm  fs.FileMode
+	filePerm fs.FileMode
 }
 
 func (upload *fileUpload) GetInfo(ctx context.Context) (handler.FileInfo, error) {
@@ -173,7 +181,7 @@ func (upload *fileUpload) GetInfo(ctx context.Context) (handler.FileInfo, error)
 }
 
 func (upload *fileUpload) WriteChunk(ctx context.Context, offset int64, src io.Reader) (int64, error) {
-	file, err := os.OpenFile(upload.binPath, os.O_WRONLY|os.O_APPEND, defaultFilePerm)
+	file, err := os.OpenFile(upload.binPath, os.O_WRONLY|os.O_APPEND, upload.filePerm)
 	if err != nil {
 		return 0, err
 	}
@@ -212,7 +220,7 @@ func (upload *fileUpload) Terminate(ctx context.Context) error {
 }
 
 func (upload *fileUpload) ConcatUploads(ctx context.Context, uploads []handler.Upload) (err error) {
-	file, err := os.OpenFile(upload.binPath, os.O_WRONLY|os.O_APPEND, defaultFilePerm)
+	file, err := os.OpenFile(upload.binPath, os.O_WRONLY|os.O_APPEND, upload.filePerm)
 	if err != nil {
 		return err
 	}
@@ -253,7 +261,7 @@ func (upload *fileUpload) writeInfo() error {
 	if err != nil {
 		return err
 	}
-	return createFile(upload.infoPath, data)
+	return createFile(upload.infoPath, upload.dirPerm, upload.filePerm, data)
 }
 
 func (upload *fileUpload) FinishUpload(ctx context.Context) error {
@@ -262,19 +270,19 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) error {
 
 // createFile creates the file with the content. If the corresponding directory does not exist,
 // it is created. If the file already exists, its content is removed.
-func createFile(path string, content []byte) error {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, defaultFilePerm)
+func createFile(path string, dirPerm fs.FileMode, filePerm fs.FileMode, content []byte) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, filePerm)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// An upload ID containing slashes is mapped onto different directories on disk,
 			// for example, `myproject/uploadA` should be put into a folder called `myproject`.
 			// If we get an error indicating that a directory is missing, we try to create it.
-			if err := os.MkdirAll(filepath.Dir(path), defaultDirectoryPerm); err != nil {
+			if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
 				return fmt.Errorf("failed to create directory for %s: %s", path, err)
 			}
 
 			// Try creating the file again.
-			file, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, defaultFilePerm)
+			file, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, filePerm)
 			if err != nil {
 				// If that still doesn't work, error out.
 				return err

--- a/pkg/handler/composer_test.go
+++ b/pkg/handler/composer_test.go
@@ -9,7 +9,7 @@ import (
 func ExampleNewStoreComposer() {
 	composer := handler.NewStoreComposer()
 
-	fs := filestore.New("./data")
+	fs := filestore.New("./data", 0774, 0664)
 	fs.UseIn(composer)
 
 	ml := memorylocker.New()

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -19,7 +19,7 @@ func TestNewHandlerWithHooks(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	store := filestore.New("some-path")
+	store := filestore.New("some-path", 0774, 0664)
 	config := handler.Config{
 		StoreComposer: handler.NewStoreComposer(),
 	}


### PR DESCRIPTION
Hi.

This pool request allows flexible use of DAC access attributes to access intermediate directories, if used.