### PR TITLE
filestore: Expose `.info` path and fix absolute paths

### DIFF
--- a/docs/_advanced-topics/hooks.md
+++ b/docs/_advanced-topics/hooks.md
@@ -83,9 +83,11 @@ Below you can find an annotated, JSON-ish encoded example of a hook request:
             // Storage contains information about where the upload is stored. The exact values
             // depend on the storage that is used and are not available in the pre-create hook.
             "Storage": {
-                 // For example, the filestore supplies the absolute file path:
+                 // For example, the filestore supplies the absolute file paths where the upload data
+                 // (Path) and the associated info file (InfoPath) are stored:
                  "Type": "filestore",
                  "Path": "/my/upload/directory/14b1c4c77771671a8479bc0444bbc5ce",
+                 "InfoPath": "/my/upload/directory/14b1c4c77771671a8479bc0444bbc5ce.info",
 
                  // The S3Store and GCSStore supply the bucket name and object key:
                  "Type": "s3store",

--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -75,8 +75,9 @@ func (store FileStore) NewUpload(ctx context.Context, info handler.FileInfo) (ha
 	}
 
 	info.Storage = map[string]string{
-		"Type": "filestore",
-		"Path": binPath,
+		"Type":     "filestore",
+		"Path":     binPath,
+		"InfoPath": infoPath,
 	}
 
 	// Create binary file with no content

--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -62,7 +62,14 @@ func (store FileStore) NewUpload(ctx context.Context, info handler.FileInfo) (ha
 	// The binary file's location might be modified by the pre-create hook.
 	var binPath string
 	if info.Storage != nil && info.Storage["Path"] != "" {
-		binPath = filepath.Join(store.Path, info.Storage["Path"])
+		// filepath.Join treats absolute and relative paths the same, so we must
+		// handle them on our own. Absolute paths get used as-is, while relative
+		// paths are joined to the storage path.
+		if filepath.IsAbs(info.Storage["Path"]) {
+			binPath = info.Storage["Path"]
+		} else {
+			binPath = filepath.Join(store.Path, info.Storage["Path"])
+		}
 	} else {
 		binPath = store.defaultBinPath(info.ID)
 	}

--- a/pkg/filestore/filestore_test.go
+++ b/pkg/filestore/filestore_test.go
@@ -43,9 +43,10 @@ func TestFilestore(t *testing.T) {
 	a.EqualValues(42, info.Size)
 	a.EqualValues(0, info.Offset)
 	a.Equal(handler.MetaData{"hello": "world"}, info.MetaData)
-	a.Equal(2, len(info.Storage))
+	a.Equal(3, len(info.Storage))
 	a.Equal("filestore", info.Storage["Type"])
 	a.Equal(filepath.Join(tmp, info.ID), info.Storage["Path"])
+	a.Equal(filepath.Join(tmp, info.ID+".info"), info.Storage["InfoPath"])
 
 	// Write data to upload
 	bytesWritten, err := upload.WriteChunk(ctx, 0, strings.NewReader("hello world"))
@@ -104,9 +105,10 @@ func TestCreateDirectories(t *testing.T) {
 	a.EqualValues(42, info.Size)
 	a.EqualValues(0, info.Offset)
 	a.Equal(handler.MetaData{"hello": "world"}, info.MetaData)
-	a.Equal(2, len(info.Storage))
+	a.Equal(3, len(info.Storage))
 	a.Equal("filestore", info.Storage["Type"])
 	a.Equal(filepath.Join(tmp, info.ID), info.Storage["Path"])
+	a.Equal(filepath.Join(tmp, info.ID+".info"), info.Storage["InfoPath"])
 
 	// Write data to upload
 	bytesWritten, err := upload.WriteChunk(ctx, 0, strings.NewReader("hello world"))
@@ -273,9 +275,10 @@ func TestCustomRelativePath(t *testing.T) {
 	a.NoError(err)
 	a.EqualValues(42, info.Size)
 	a.EqualValues(0, info.Offset)
-	a.Equal(2, len(info.Storage))
+	a.Equal(3, len(info.Storage))
 	a.Equal("filestore", info.Storage["Type"])
 	a.Equal(filepath.Join(tmp, "./folder2/bin"), info.Storage["Path"])
+	a.Equal(filepath.Join(tmp, "./folder1/info.info"), info.Storage["InfoPath"])
 
 	// Write data to upload
 	bytesWritten, err := upload.WriteChunk(ctx, 0, strings.NewReader("hello world"))
@@ -346,9 +349,10 @@ func TestCustomAbsolutePath(t *testing.T) {
 	a.NoError(err)
 	a.EqualValues(42, info.Size)
 	a.EqualValues(0, info.Offset)
-	a.Equal(2, len(info.Storage))
+	a.Equal(3, len(info.Storage))
 	a.Equal("filestore", info.Storage["Type"])
 	a.Equal(binPath, info.Storage["Path"])
+	a.Equal(filepath.Join(tmp1, "my-upload.info"), info.Storage["InfoPath"])
 
 	statInfo, err := os.Stat(binPath)
 	a.NoError(err)


### PR DESCRIPTION
This PR includes two changes:

- When the `pre-create` hooks specifies an absolute path where the blob file should be stored, the absolute path was wrongfully joined to the storage directory and treated as relative. This PR fixes this.
- The location of the `.info` file is no exposed to hooks as `Storage.InfoPath`.