### PR TITLE
http2 cleartext support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tusd_*_*
 __pycache__/
 examples/hooks/plugin/hook_handler
 .idea/
+.vscode/

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -15,6 +15,7 @@ var Flags struct {
 	HttpHost                         string
 	HttpPort                         string
 	HttpSock                         string
+	EnableH2C                        bool
 	MaxSize                          int64
 	UploadDir                        string
 	Basepath                         string
@@ -87,6 +88,7 @@ func ParseFlags() {
 		f.StringVar(&Flags.HttpSock, "unix-sock", "", "If set, will listen to a UNIX socket at this location instead of a TCP socket")
 		f.StringVar(&Flags.Basepath, "base-path", "/files/", "Basepath of the HTTP server")
 		f.BoolVar(&Flags.BehindProxy, "behind-proxy", false, "Respect X-Forwarded-* and similar headers which may be set by proxies")
+		f.BoolVar(&Flags.EnableH2C, "enable-h2c", false, "Allow for HTTP/2 cleartext (h2c) connections (non-encrypted) via http scheme")
 	})
 
 	fs.AddGroup("TLS options", func(f *flag.FlagSet) {

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -15,6 +15,9 @@ import (
 	tushandler "github.com/tus/tusd/v2/pkg/handler"
 	"github.com/tus/tusd/v2/pkg/hooks"
 	"github.com/tus/tusd/v2/pkg/hooks/plugin"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 const (
@@ -160,6 +163,11 @@ func Serve() {
 
 	if protocol == "http" {
 		// Non-TLS mode
+
+		// Wrap in h2c for optional HTTP/2 support in clear text mode
+		h2s := &http2.Server{}
+		newHandler := h2c.NewHandler(mux, h2s)
+		server.Handler = newHandler
 		err = server.Serve(listener)
 	} else {
 		// TLS mode

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -163,11 +163,12 @@ func Serve() {
 
 	if protocol == "http" {
 		// Non-TLS mode
-
-		// Wrap in h2c for optional HTTP/2 support in clear text mode
-		h2s := &http2.Server{}
-		newHandler := h2c.NewHandler(mux, h2s)
-		server.Handler = newHandler
+		if Flags.EnableH2C {
+			// Wrap in h2c for optional HTTP/2 support in clear text mode
+			h2s := &http2.Server{}
+			newHandler := h2c.NewHandler(mux, h2s)
+			server.Handler = newHandler
+		}
 		err = server.Serve(listener)
 	} else {
 		// TLS mode

--- a/docs/_getting-started/configuration.md
+++ b/docs/_getting-started/configuration.md
@@ -24,7 +24,7 @@ $ tusd -host 127.0.0.1 -port 1337
 
 Once running, tusd accepts HTTP/1.1 requests on the configured port. 
 
-If [HTTPS/TLS](#httpstls) is configured, tusd will also accept an encrypted HTTP/2 connection, thanks to [Go's transparent support](https://pkg.go.dev/net/http#hdr-HTTP_2). If a cleartext HTTP/2 connection is desired instead (e.g. if hosting within GCP Cloud Run, which receives TLS HTTP/2 and proxies as cleartext http to its running containers), tusd provides this without additional configuration needed, thanks to [Go's http2 h2c support](https://pkg.go.dev/golang.org/x/net/http2/h2c#section-documentation). (Just make sure to use the `-behind-proxy` flag if applicable). 
+If [HTTPS/TLS](#httpstls) is configured, tusd will also accept an encrypted HTTP/2 connection, thanks to [Go's transparent support](https://pkg.go.dev/net/http#hdr-HTTP_2). If a cleartext HTTP/2 connection is desired instead (e.g. if hosting within GCP Cloud Run, which receives TLS HTTP/2 and proxies as cleartext http to its running containers), tusd can be configured with the `-enable-h2c` flag, thanks to [Go's http2 h2c support](https://pkg.go.dev/golang.org/x/net/http2/h2c#section-documentation). (Just make sure to use the `-behind-proxy` flag if applicable). 
 
 ### UNIX socket
 

--- a/docs/_getting-started/configuration.md
+++ b/docs/_getting-started/configuration.md
@@ -22,7 +22,9 @@ By default, tusd listens on port 8080 and all available interfaces. This can be 
 $ tusd -host 127.0.0.1 -port 1337
 ```
 
-Once running, tusd accepts HTTP/1.1 requests on the configured port. If [HTTPS/TLS](#httpstls) is configured, tusd will also accept HTTP/2 connection, thanks to [Go's transparent support](https://pkg.go.dev/net/http#hdr-HTTP_2). HTTP/3 and QUIC is currently not supported by tusd directly and requires the use of a reverse proxy.
+Once running, tusd accepts HTTP/1.1 requests on the configured port. 
+
+If [HTTPS/TLS](#httpstls) is configured, tusd will also accept an encrypted HTTP/2 connection, thanks to [Go's transparent support](https://pkg.go.dev/net/http#hdr-HTTP_2). If a cleartext HTTP/2 connection is desired instead (e.g. if hosting within GCP Cloud Run, which receives TLS HTTP/2 and proxies as cleartext http to its running containers), tusd provides this without additional configuration needed, thanks to [Go's http2 h2c support](https://pkg.go.dev/golang.org/x/net/http2/h2c#section-documentation). (Just make sure to use the `-behind-proxy` flag if applicable). 
 
 ### UNIX socket
 

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/tus/lockfile v1.2.0
 	github.com/vimeo/go-util v1.4.1
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
+	golang.org/x/net v0.26.0
 	google.golang.org/api v0.187.0
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
@@ -90,7 +91,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	golang.org/x/crypto v0.24.0 // indirect
-	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect


### PR DESCRIPTION
This PR is in reference to [this](https://github.com/tus/tus-js-client/issues/700#issuecomment-2208270992) thread in the tus-js-client repository issues. @Acconut invited us to create a lightweight PR to solve this issue, on the tusd side. 

PROBLEM

In GCP Cloud Run, HTTP/2 traffic is accepted but TLS is terminated at the load balancer and traffic is forwarded to the tusd container as cleartext (non-encrypted) http. This is problematic because tusd expects TLS for HTTP/2 traffic. 

SOLUTION

[Golang's net/http2 library ](https://pkg.go.dev/golang.org/x/net/http2/h2c#section-documentation) allows for a drop in support of HTTP/2 in cleartext (h2c), with simultaneous capability for HTTP/1.1 cleartext. Meaning, if traffic is identified to be HTTP/1.1, the h2c handler will bypass HTTP/2 and serve based on HTTP/1.1. 

This PR uses the `newHandler()` method to wrap the existing `mux` handler, such that no additional configuration is needed  to handle either HTTP version. HTTP/2 encrypted traffic can also be handled as usual by making calls directly to tusd via https. If behind a load balancer such as Cloud Run, all that would be required in terms of configuration is the `-behind-proxy` flag. 

TESTING
We built an image based on this PR and tested it for file uploads on Cloud Run with tus-js-client and it performed successfully. 