### PR TITLE
hooks: Add option to forward HTTP header to gRPC requests

### DIFF
--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -59,6 +59,7 @@ var Flags struct {
 	GrpcHooksServerTLSCertFile       string
 	GrpcHooksClientTLSCertFile       string
 	GrpcHooksClientTLSKeyFile        string
+	GrpcHooksForwardHeaders          string
 	EnabledHooks                     []hooks.HookType
 	ProgressHooksInterval            time.Duration
 	ShowVersion                      bool
@@ -173,6 +174,7 @@ func ParseFlags() {
 		f.StringVar(&Flags.GrpcHooksServerTLSCertFile, "hooks-grpc-server-tls-certificate", "", "Path to the file containing the TLS certificate of the remote gRPC server")
 		f.StringVar(&Flags.GrpcHooksClientTLSCertFile, "hooks-grpc-client-tls-certificate", "", "Path to the file containing the client certificate for mTLS")
 		f.StringVar(&Flags.GrpcHooksClientTLSKeyFile, "hooks-grpc-client-tls-key", "", "Path to the file containing the client key for mTLS")
+		f.StringVar(&Flags.GrpcHooksForwardHeaders, "hooks-grpc-forward-headers", "", "List of HTTP request headers to be forwarded from the client request to the hook endpoint")
 	})
 
 	fs.AddGroup("Plugin hook options", func(f *flag.FlagSet) {

--- a/cmd/tusd/cli/hooks.go
+++ b/cmd/tusd/cli/hooks.go
@@ -38,6 +38,7 @@ func getHookHandler(config *handler.Config) hooks.HookHandler {
 			ServerTLSCertificateFilePath:    Flags.GrpcHooksServerTLSCertFile,
 			ClientTLSCertificateFilePath:    Flags.GrpcHooksClientTLSCertFile,
 			ClientTLSCertificateKeyFilePath: Flags.GrpcHooksClientTLSKeyFile,
+			ForwardHeaders:                  strings.Split(Flags.GrpcHooksForwardHeaders, ","),
 		}
 	} else if Flags.PluginHookPath != "" {
 		stdout.Printf("Using '%s' to load plugin for hooks", Flags.PluginHookPath)


### PR DESCRIPTION
This adds the `-hooks-grpc-forward-headers` option to forward a list of selected header fields from the request to tusd to the gRPC request to the gRPC server. Can be useful for passing through Authorization headers.

Closes https://github.com/tus/tusd/issues/1112.