### PR TITLE
Add note about port of X-Forwarded-Host to nginx.conf example

### DIFF
--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -57,6 +57,7 @@ server {
         proxy_http_version       1.1;
 
         # Add X-Forwarded-* headers
+        # Replace $host with $host:$server_post if server is not listening on 80/443
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
 


### PR DESCRIPTION
tusd will use `X-Forwarded-Host` as the host if `-behind-proxy` is enabled. However, the example Nginx config doesn't put the port number into `X-Forwarded-Host`, but only the address. This makes the URL returned by tusd to be on port 80/443 instead of what Nginx is actually listening on.

Changing `proxy_set_header X-Forwarded-Host $host` to `proxy_set_header X-Forwarded-Host $host:$server_port` can fix this problem. But this leads to the occurrence of `:80`/`:443` in the returned URL even the client doesn't put `:80`/`:443` in the `Host` header, which can be a little weird. So I just add a comment about this.

Related issue: #136