### PR TITLE
cli: Allow Application Default Credentials discovery for GCP

### DIFF
--- a/cmd/tusd/cli/composer.go
+++ b/cmd/tusd/cli/composer.go
@@ -76,8 +76,8 @@ func CreateComposer() {
 				"Please remove underscore from the value", Flags.GCSObjectPrefix)
 		}
 
-		// Legacy: account file used to be provided by GCS_SERVICE_ACCOUNT_FILE environment variable.
-		// Now it is more common to default into ADC discovery mechanism.
+		// Application Default Credentials discovery mechanism is attempted to fetch credentials,
+		// but an account file can be provided through the GCS_SERVICE_ACCOUNT_FILE environment variable.
 		gcsSAF := os.Getenv("GCS_SERVICE_ACCOUNT_FILE")
 
 		service, err := gcsstore.NewGCSService(gcsSAF)

--- a/cmd/tusd/cli/composer.go
+++ b/cmd/tusd/cli/composer.go
@@ -76,12 +76,9 @@ func CreateComposer() {
 				"Please remove underscore from the value", Flags.GCSObjectPrefix)
 		}
 
-		// Derivce credentials from service account file path passed in
-		// GCS_SERVICE_ACCOUNT_FILE environment variable.
+		// Legacy: account file used to be provided by GCS_SERVICE_ACCOUNT_FILE environment variable.
+		// Now it is more common to default into ADC discovery mechanism.
 		gcsSAF := os.Getenv("GCS_SERVICE_ACCOUNT_FILE")
-		if gcsSAF == "" {
-			stderr.Fatalf("No service account file provided for Google Cloud Storage using the GCS_SERVICE_ACCOUNT_FILE environment variable.\n")
-		}
 
 		service, err := gcsstore.NewGCSService(gcsSAF)
 		if err != nil {

--- a/docs/_storage-backends/google-cloud-storage.md
+++ b/docs/_storage-backends/google-cloud-storage.md
@@ -18,7 +18,8 @@ $ tusd -gcs-bucket=my-test-bucket.com
 ...
 ```
 
-By default, Application Default Credentials [discovery mechanism](https://cloud.google.com/docs/authentication/external/set-up-adc) will be attempted.
+By default, [Application Default Credentials discovery mechanism](https://cloud.google.com/docs/authentication/external/set-up-adc) will be attempted.
+
 If `GCS_SERVICE_ACCOUNT_FILE` environment variable is provided, that account will be used instead:
 
 ```bash

--- a/docs/_storage-backends/google-cloud-storage.md
+++ b/docs/_storage-backends/google-cloud-storage.md
@@ -6,11 +6,20 @@ nav_order: 5
 
 # Google Cloud Storage
 
-Tusd can store files directly on Google Cloud Storage. The uploaded file is directly transferred to S3 while the user is performing the upload without storing the entire file on disk first.
+Tusd can store files directly on Google Cloud Storage. The uploaded file is directly transferred to Storage Bucket while the user is performing the upload without storing the entire file on disk first.
 
 ## Configuration
 
-To enable this backend, you must supply the path to the corresponding account file using environment variables and specify the bucket name using `-gcs-bucket`, for example:
+To enable this backend, you must specify the bucket name using `-gcs-bucket`, for example:
+
+```bash
+$ tusd -gcs-bucket=my-test-bucket.com
+[tusd] Using 'gcs://my-test-bucket.com' as GCS bucket for storage.
+...
+```
+
+By default, Application Default Credentials [discovery mechanism](https://cloud.google.com/docs/authentication/external/set-up-adc) will be attempted.
+If `GCS_SERVICE_ACCOUNT_FILE` environment variable is provided, that account will be used instead:
 
 ```bash
 $ export GCS_SERVICE_ACCOUNT_FILE=./account.json

--- a/pkg/gcsstore/gcsservice.go
+++ b/pkg/gcsstore/gcsservice.go
@@ -81,7 +81,12 @@ type GCSService struct {
 // NewGCSService returns a GCSService object given a GCloud service account file path.
 func NewGCSService(filename string) (*GCSService, error) {
 	ctx := context.Background()
-	client, err := storage.NewClient(ctx, option.WithCredentialsFile(filename))
+	var opts []option.ClientOption
+	if filename != "" {
+		opts = append(opts, option.WithCredentialsFile(filename))
+	}
+	client, err := storage.NewClient(ctx, opts...)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When deploying tusd under GCP, it is better to use integrated Application Default Credentials discovery mechanism, that exists under most google SDK's.

This change simply allows _not_ providing any string as credential file, and then client library defaults to trying ADC as per https://cloud.google.com/docs/authentication/application-default-credentials 

If this proposal is acceptable, I could update the readme as well.