### PR TITLE
handler, s3store: Serve GET requests directly from S3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/tus/tusd/v2
 // Specify the Go version needed for the Heroku deployment
 // See https://github.com/heroku/heroku-buildpack-go#go-module-specifics
 // +heroku goVersion go1.22
-go 1.21.0
+go 1.22.1
 
 toolchain go1.22.7
 

--- a/pkg/handler/composer.go
+++ b/pkg/handler/composer.go
@@ -14,6 +14,8 @@ type StoreComposer struct {
 	Concater           ConcaterDataStore
 	UsesLengthDeferrer bool
 	LengthDeferrer     LengthDeferrerDataStore
+	ContentServer      ContentServerDataStore
+	UsesContentServer  bool
 }
 
 // NewStoreComposer creates a new and empty store composer.
@@ -84,4 +86,8 @@ func (store *StoreComposer) UseConcater(ext ConcaterDataStore) {
 func (store *StoreComposer) UseLengthDeferrer(ext LengthDeferrerDataStore) {
 	store.UsesLengthDeferrer = ext != nil
 	store.LengthDeferrer = ext
+}
+func (store *StoreComposer) UseContentServer(ext ContentServerDataStore) {
+	store.UsesContentServer = ext != nil
+	store.ContentServer = ext
 }

--- a/pkg/handler/datastore.go
+++ b/pkg/handler/datastore.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"io"
+	"net/http"
 )
 
 type MetaData map[string]string
@@ -119,6 +120,16 @@ type DataStore interface {
 	// GetUpload fetches the upload with a given ID. If no such upload can be found,
 	// ErrNotFound must be returned.
 	GetUpload(ctx context.Context, id string) (upload Upload, err error)
+}
+
+// ServableUpload defines the method for serving content directly
+type ServableUpload interface {
+	ServeContent(ctx context.Context, w http.ResponseWriter, r *http.Request) error
+}
+
+// ContentServerDataStore is the interface for data stores that can serve content directly
+type ContentServerDataStore interface {
+	AsServableUpload(upload Upload) ServableUpload
 }
 
 type TerminatableUpload interface {

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -1047,6 +1047,17 @@ func (handler *UnroutedHandler) GetFile(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// If the data store implements ContentServerDataStore, use the ServableUpload interface
+	if handler.composer.UsesContentServer {
+		servableUpload := handler.composer.ContentServer.AsServableUpload(upload)
+		err = servableUpload.ServeContent(c, w, r)
+		if err != nil {
+			handler.sendError(c, err)
+		}
+		return
+	}
+
+	// Fall back to the existing GetReader implementation if ContentServerDataStore is not implemented
 	contentType, contentDisposition := filterContentType(info)
 	resp := HTTPResponse{
 		StatusCode: http.StatusOK,


### PR DESCRIPTION
- Add ContentServerDataStore interface
- Update handlers to use ContentServerDataStore when available
- Implement range request handling for s3upload
- Add tests for new ContentServerDataStore functionality
- Update Go version to 1.22.1

Closes #1064