### PR TITLE
handler: unwrap errors using `errors.As`

### DIFF
--- a/pkg/handler/patch_test.go
+++ b/pkg/handler/patch_test.go
@@ -3,6 +3,7 @@ package handler_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -140,7 +141,10 @@ func TestPatch(t *testing.T) {
 	})
 
 	SubTest(t, "UploadNotFoundFail", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
-		store.EXPECT().GetUpload(gomock.Any(), "no").Return(nil, ErrNotFound)
+		// we wrap the error in order to ensure proper error handling
+		err := fmt.Errorf("extra info: %w", ErrNotFound)
+
+		store.EXPECT().GetUpload(gomock.Any(), "no").Return(nil, err)
 
 		handler, _ := NewHandler(Config{
 			StoreComposer: composer,

--- a/pkg/handler/patch_test.go
+++ b/pkg/handler/patch_test.go
@@ -141,7 +141,8 @@ func TestPatch(t *testing.T) {
 	})
 
 	SubTest(t, "UploadNotFoundFail", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
-		// we wrap the error in order to ensure proper error handling
+		// We wrap the error test whether the handler correctly unwraps it again
+		// to get an handler.Error.
 		err := fmt.Errorf("extra info: %w", ErrNotFound)
 
 		store.EXPECT().GetUpload(gomock.Any(), "no").Return(nil, err)

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -1185,8 +1185,9 @@ func (handler *UnroutedHandler) terminateUpload(c *httpContext, upload Upload, i
 func (handler *UnroutedHandler) sendError(c *httpContext, err error) {
 	r := c.req
 
-	detailedErr, ok := err.(Error)
-	if !ok {
+	var detailedErr Error
+
+	if !errors.As(err, &detailedErr) {
 		c.log.Error("InternalServerError", "message", err.Error())
 		detailedErr = NewError("ERR_INTERNAL_SERVER_ERROR", err.Error(), http.StatusInternalServerError)
 	}


### PR DESCRIPTION
A datastore may wrap errors with additional information. Before the fix, the error was converted to the InternalServerError type by the handler.