### PR TITLE
handler: Support IETF draft -04 and -05

### DIFF
--- a/pkg/handler/head_test.go
+++ b/pkg/handler/head_test.go
@@ -176,6 +176,7 @@ func TestHead(t *testing.T) {
 						ResHeader: addIETFUploadCompleteHeader(map[string]string{
 							"Upload-Draft-Interop-Version": interopVersion,
 							"Upload-Offset":                "5",
+							"Upload-Length":                "10",
 						}, false, interopVersion),
 					}).Run(handler, t)
 				})
@@ -209,6 +210,7 @@ func TestHead(t *testing.T) {
 						ResHeader: addIETFUploadCompleteHeader(map[string]string{
 							"Upload-Draft-Interop-Version": interopVersion,
 							"Upload-Offset":                "10",
+							"Upload-Length":                "10",
 						}, true, interopVersion),
 					}).Run(handler, t)
 				})
@@ -241,6 +243,7 @@ func TestHead(t *testing.T) {
 						ResHeader: addIETFUploadCompleteHeader(map[string]string{
 							"Upload-Draft-Interop-Version": interopVersion,
 							"Upload-Offset":                "5",
+							"Upload-Length":                "",
 						}, false, interopVersion),
 					}).Run(handler, t)
 				})

--- a/pkg/handler/head_test.go
+++ b/pkg/handler/head_test.go
@@ -145,7 +145,7 @@ func TestHead(t *testing.T) {
 	})
 
 	SubTest(t, "ExperimentalProtocol", func(t *testing.T, _ *MockFullDataStore, _ *StoreComposer) {
-		for _, interopVersion := range []string{"3", "4", "5"} {
+		for _, interopVersion := range []string{"3", "4", "5", "6"} {
 			SubTest(t, "InteropVersion"+interopVersion, func(t *testing.T, _ *MockFullDataStore, _ *StoreComposer) {
 				SubTest(t, "IncompleteUpload", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
 					ctrl := gomock.NewController(t)

--- a/pkg/handler/head_test.go
+++ b/pkg/handler/head_test.go
@@ -177,6 +177,7 @@ func TestHead(t *testing.T) {
 							"Upload-Draft-Interop-Version": interopVersion,
 							"Upload-Offset":                "5",
 							"Upload-Length":                "10",
+							"Upload-Limit":                 "min-size=0,max-size=10",
 						}, false, interopVersion),
 					}).Run(handler, t)
 				})
@@ -211,6 +212,7 @@ func TestHead(t *testing.T) {
 							"Upload-Draft-Interop-Version": interopVersion,
 							"Upload-Offset":                "10",
 							"Upload-Length":                "10",
+							"Upload-Limit":                 "min-size=0,max-size=10",
 						}, true, interopVersion),
 					}).Run(handler, t)
 				})
@@ -231,6 +233,7 @@ func TestHead(t *testing.T) {
 					handler, _ := NewHandler(Config{
 						StoreComposer:              composer,
 						EnableExperimentalProtocol: true,
+						MaxSize:                    400,
 					})
 
 					(&httpTest{
@@ -244,6 +247,7 @@ func TestHead(t *testing.T) {
 							"Upload-Draft-Interop-Version": interopVersion,
 							"Upload-Offset":                "5",
 							"Upload-Length":                "",
+							"Upload-Limit":                 "min-size=0,max-size=400",
 						}, false, interopVersion),
 					}).Run(handler, t)
 				})

--- a/pkg/handler/options_test.go
+++ b/pkg/handler/options_test.go
@@ -42,4 +42,26 @@ func TestOptions(t *testing.T) {
 			Code: http.StatusPreconditionFailed,
 		}).Run(handler, t)
 	})
+
+	SubTest(t, "ExperimentalProtocol", func(t *testing.T, store *MockFullDataStore, _ *StoreComposer) {
+		composer := NewStoreComposer()
+		composer.UseCore(store)
+
+		handler, _ := NewHandler(Config{
+			StoreComposer:              composer,
+			EnableExperimentalProtocol: true,
+			MaxSize:                    400,
+		})
+
+		(&httpTest{
+			Method: "OPTIONS",
+			ReqHeader: map[string]string{
+				"Upload-Draft-Interop-Version": "6",
+			},
+			ResHeader: map[string]string{
+				"Upload-Limit": "min-size=0,max-size=400",
+			},
+			Code: http.StatusOK,
+		}).Run(handler, t)
+	})
 }

--- a/pkg/handler/patch_test.go
+++ b/pkg/handler/patch_test.go
@@ -816,7 +816,7 @@ func TestPatch(t *testing.T) {
 	})
 
 	SubTest(t, "ExperimentalProtocol", func(t *testing.T, _ *MockFullDataStore, _ *StoreComposer) {
-		for _, interopVersion := range []string{"3", "4", "5"} {
+		for _, interopVersion := range []string{"3", "4", "5", "6"} {
 			SubTest(t, "InteropVersion"+interopVersion, func(t *testing.T, _ *MockFullDataStore, _ *StoreComposer) {
 				SubTest(t, "CompleteUploadWithKnownSize", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
 					ctrl := gomock.NewController(t)

--- a/pkg/handler/patch_test.go
+++ b/pkg/handler/patch_test.go
@@ -843,10 +843,10 @@ func TestPatch(t *testing.T) {
 					(&httpTest{
 						Method: "PATCH",
 						URL:    "yes",
-						ReqHeader: addIETFUploadCompleteHeader(map[string]string{
+						ReqHeader: addIETFContentTypeHeader(addIETFUploadCompleteHeader(map[string]string{
 							"Upload-Draft-Interop-Version": interopVersion,
 							"Upload-Offset":                "5",
-						}, true, interopVersion),
+						}, true, interopVersion), interopVersion),
 						ReqBody: strings.NewReader("hello"),
 						Code:    http.StatusNoContent,
 						ResHeader: map[string]string{
@@ -887,10 +887,10 @@ func TestPatch(t *testing.T) {
 					(&httpTest{
 						Method: "PATCH",
 						URL:    "yes",
-						ReqHeader: addIETFUploadCompleteHeader(map[string]string{
+						ReqHeader: addIETFContentTypeHeader(addIETFUploadCompleteHeader(map[string]string{
 							"Upload-Draft-Interop-Version": interopVersion,
 							"Upload-Offset":                "5",
-						}, true, interopVersion),
+						}, true, interopVersion), interopVersion),
 						ReqBody: strings.NewReader("hello"),
 						Code:    http.StatusNoContent,
 						ResHeader: map[string]string{
@@ -922,10 +922,10 @@ func TestPatch(t *testing.T) {
 					(&httpTest{
 						Method: "PATCH",
 						URL:    "yes",
-						ReqHeader: addIETFUploadCompleteHeader(map[string]string{
+						ReqHeader: addIETFContentTypeHeader(addIETFUploadCompleteHeader(map[string]string{
 							"Upload-Draft-Interop-Version": interopVersion,
 							"Upload-Offset":                "5",
-						}, false, interopVersion),
+						}, false, interopVersion), interopVersion),
 						ReqBody: strings.NewReader("hel"),
 						Code:    http.StatusNoContent,
 						ResHeader: map[string]string{
@@ -957,10 +957,10 @@ func TestPatch(t *testing.T) {
 					(&httpTest{
 						Method: "PATCH",
 						URL:    "yes",
-						ReqHeader: addIETFUploadCompleteHeader(map[string]string{
+						ReqHeader: addIETFContentTypeHeader(addIETFUploadCompleteHeader(map[string]string{
 							"Upload-Draft-Interop-Version": interopVersion,
 							"Upload-Offset":                "5",
-						}, false, interopVersion),
+						}, false, interopVersion), interopVersion),
 						ReqBody: strings.NewReader("hel"),
 						Code:    http.StatusNoContent,
 						ResHeader: map[string]string{
@@ -968,6 +968,28 @@ func TestPatch(t *testing.T) {
 						},
 					}).Run(handler, t)
 				})
+
+				if interopVersion != "3" && interopVersion != "4" && interopVersion != "5" {
+					SubTest(t, "InvalidContentType", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
+						handler, _ := NewHandler(Config{
+							StoreComposer:              composer,
+							EnableExperimentalProtocol: true,
+						})
+
+						(&httpTest{
+							Method: "PATCH",
+							URL:    "yes",
+							ReqHeader: map[string]string{
+								"Upload-Draft-Interop-Version": interopVersion,
+								"Content-Type":                 "application/not-partial-upload",
+								"Upload-Offset":                "0",
+							},
+							ReqBody: strings.NewReader("test"),
+							Code:    http.StatusBadRequest,
+							ResBody: "ERR_INVALID_CONTENT_TYPE: missing or invalid Content-Type header\n",
+						}).Run(handler, t)
+					})
+				}
 			})
 		}
 	})

--- a/pkg/handler/post_test.go
+++ b/pkg/handler/post_test.go
@@ -546,7 +546,7 @@ func TestPost(t *testing.T) {
 	})
 
 	SubTest(t, "ExperimentalProtocol", func(t *testing.T, _ *MockFullDataStore, _ *StoreComposer) {
-		for _, interopVersion := range []string{"3", "4", "5"} {
+		for _, interopVersion := range []string{"3", "4", "5", "6"} {
 			SubTest(t, "InteropVersion"+interopVersion, func(t *testing.T, _ *MockFullDataStore, _ *StoreComposer) {
 				SubTest(t, "CompleteUpload", func(t *testing.T, store *MockFullDataStore, _ *StoreComposer) {
 					ctrl := gomock.NewController(t)

--- a/pkg/handler/post_test.go
+++ b/pkg/handler/post_test.go
@@ -603,6 +603,7 @@ func TestPost(t *testing.T) {
 							"Upload-Draft-Interop-Version": interopVersion,
 							"Location":                     "http://tus.io/files/foo",
 							"Upload-Offset":                "11",
+							"Upload-Limit":                 "min-size=0,max-size=11",
 						},
 					}).Run(handler, t)
 
@@ -614,6 +615,7 @@ func TestPost(t *testing.T) {
 								"Upload-Draft-Interop-Version": []string{interopVersion},
 								"Location":                     []string{"http://tus.io/files/foo"},
 								"X-Content-Type-Options":       []string{"nosniff"},
+								"Upload-Limit":                 []string{"min-size=0,max-size=11"},
 							},
 						},
 					}, res.InformationalResponses)
@@ -650,6 +652,7 @@ func TestPost(t *testing.T) {
 						StoreComposer:              composer,
 						BasePath:                   "/files/",
 						EnableExperimentalProtocol: true,
+						MaxSize:                    400,
 					})
 
 					res := (&httpTest{
@@ -663,6 +666,7 @@ func TestPost(t *testing.T) {
 							"Upload-Draft-Interop-Version": interopVersion,
 							"Location":                     "http://tus.io/files/foo",
 							"Upload-Offset":                "11",
+							"Upload-Limit":                 "min-size=0,max-size=400",
 						},
 					}).Run(handler, t)
 
@@ -674,6 +678,7 @@ func TestPost(t *testing.T) {
 								"Upload-Draft-Interop-Version": []string{interopVersion},
 								"Location":                     []string{"http://tus.io/files/foo"},
 								"X-Content-Type-Options":       []string{"nosniff"},
+								"Upload-Limit":                 []string{"min-size=0,max-size=400"},
 							},
 						},
 					}, res.InformationalResponses)
@@ -728,6 +733,7 @@ func TestPost(t *testing.T) {
 								"Upload-Draft-Interop-Version": interopVersion,
 								"Location":                     "http://tus.io/files/foo",
 								"Upload-Offset":                "11",
+								"Upload-Limit":                 "min-size=0,max-size=11",
 							},
 						}).Run(handler, t)
 					})
@@ -802,6 +808,7 @@ func TestPost(t *testing.T) {
 								"Upload-Draft-Interop-Version": interopVersion,
 								"Location":                     "http://tus.io/files/foo",
 								"Upload-Offset":                "6",
+								"Upload-Limit":                 "min-size=0,max-size=11",
 							},
 						}).Run(handler, t)
 					})

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -680,6 +680,8 @@ func (handler *UnroutedHandler) HeadFile(w http.ResponseWriter, r *http.Request)
 			resp.Header["Upload-Defer-Length"] = UploadLengthDeferred
 		} else {
 			resp.Header["Upload-Length"] = strconv.FormatInt(info.Size, 10)
+			// TODO: Shouldn't this rather be offset? Basically, whatever GET would return.
+			// But this then also depends on the storage backend if that's even supported.
 			resp.Header["Content-Length"] = strconv.FormatInt(info.Size, 10)
 		}
 
@@ -688,6 +690,10 @@ func (handler *UnroutedHandler) HeadFile(w http.ResponseWriter, r *http.Request)
 		isUploadCompleteNow := !info.SizeIsDeferred && info.Offset == info.Size
 		setIETFDraftUploadComplete(r, resp, isUploadCompleteNow)
 		resp.Header["Upload-Draft-Interop-Version"] = string(getIETFDraftInteropVersion(r))
+
+		if !info.SizeIsDeferred {
+			resp.Header["Upload-Length"] = strconv.FormatInt(info.Size, 10)
+		}
 
 		// Draft -01 and -02 require a 204 No Content response. Version -03 allows 200 OK as well,
 		// but we stick to 204 to not make the logic less complex.

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -236,8 +236,16 @@ func (handler *UnroutedHandler) Middleware(h http.Handler) http.Handler {
 		// Set appropriated headers in case of OPTIONS method allowing protocol
 		// discovery and end with an 204 No Content
 		if r.Method == "OPTIONS" {
+			ietfDraftLimits := "min-size=0"
+
 			if handler.config.MaxSize > 0 {
-				header.Set("Tus-Max-Size", strconv.FormatInt(handler.config.MaxSize, 10))
+				maxSizeStr := strconv.FormatInt(handler.config.MaxSize, 10)
+				header.Set("Tus-Max-Size", maxSizeStr)
+				ietfDraftLimits += ",max-size=" + maxSizeStr
+			}
+
+			if handler.usesIETFDraft(r) {
+				header.Set("Upload-Limit", ietfDraftLimits)
 			}
 
 			header.Set("Tus-Version", "1.0.0")

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -28,6 +28,7 @@ const (
 	interopVersion3 draftVersion = "3" // From draft version -01
 	interopVersion4 draftVersion = "4" // From draft version -02
 	interopVersion5 draftVersion = "5" // From draft version -03
+	interopVersion6 draftVersion = "6" // From draft version -04 and -05
 )
 
 var (
@@ -1381,7 +1382,7 @@ func (handler UnroutedHandler) usesIETFDraft(r *http.Request) bool {
 func getIETFDraftInteropVersion(r *http.Request) draftVersion {
 	version := draftVersion(r.Header.Get("Upload-Draft-Interop-Version"))
 	switch version {
-	case interopVersion3, interopVersion4, interopVersion5:
+	case interopVersion3, interopVersion4, interopVersion5, interopVersion6:
 		return version
 	default:
 		return ""
@@ -1393,7 +1394,7 @@ func getIETFDraftInteropVersion(r *http.Request) draftVersion {
 func isIETFDraftUploadComplete(r *http.Request) bool {
 	currentUploadDraftInteropVersion := getIETFDraftInteropVersion(r)
 	switch currentUploadDraftInteropVersion {
-	case interopVersion4, interopVersion5:
+	case interopVersion4, interopVersion5, interopVersion6:
 		return r.Header.Get("Upload-Complete") == "?1"
 	case interopVersion3:
 		return r.Header.Get("Upload-Incomplete") == "?0"
@@ -1414,7 +1415,7 @@ func setIETFDraftUploadComplete(r *http.Request, resp HTTPResponse, isComplete b
 		} else {
 			resp.Header["Upload-Incomplete"] = "?1"
 		}
-	case interopVersion4, interopVersion5:
+	case interopVersion4, interopVersion5, interopVersion6:
 		if isComplete {
 			resp.Header["Upload-Complete"] = "?1"
 		} else {

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -706,6 +706,8 @@ func (handler *UnroutedHandler) HeadFile(w http.ResponseWriter, r *http.Request)
 			resp.Header["Upload-Length"] = strconv.FormatInt(info.Size, 10)
 		}
 
+		resp.Header["Upload-Limit"] = handler.getIETFDraftUploadLimits(info)
+
 		// Draft -01 and -02 require a 204 No Content response. Version -03 allows 200 OK as well,
 		// but we stick to 204 to not make the logic less complex.
 		resp.StatusCode = http.StatusNoContent

--- a/pkg/handler/utils_test.go
+++ b/pkg/handler/utils_test.go
@@ -152,3 +152,12 @@ func addIETFUploadCompleteHeader(header map[string]string, isComplete bool, inte
 
 	return header
 }
+
+// addIETFContentTypeHeader writes the Content-Type header depending on the interop version.
+func addIETFContentTypeHeader(header map[string]string, interopVersion string) map[string]string {
+	switch interopVersion {
+	case "6":
+		header["Content-Type"] = "application/partial-upload"
+	}
+	return header
+}

--- a/pkg/handler/utils_test.go
+++ b/pkg/handler/utils_test.go
@@ -142,7 +142,7 @@ func addIETFUploadCompleteHeader(header map[string]string, isComplete bool, inte
 		} else {
 			header["Upload-Incomplete"] = "?1"
 		}
-	case "4", "5":
+	case "4", "5", "6":
 		if isComplete {
 			header["Upload-Complete"] = "?1"
 		} else {


### PR DESCRIPTION
Support for [-04](https://datatracker.ietf.org/doc/draft-ietf-httpbis-resumable-upload/04/) and [-05](https://datatracker.ietf.org/doc/draft-ietf-httpbis-resumable-upload/05/). All changes can be seen in https://www.ietf.org/archive/id/draft-ietf-httpbis-resumable-upload-05.html#name-changes, but the relevant changes for tusd are:

- [x] Upload-Draft-Interop-Version: 6
- [x] Upload-Length header in POST requests and HEAD responses
- [x] Upload-Limit in responses to resource (HEAD, POST)
- [x] Upload-Limit in OPTIONS response
- [x] application/partial-upload media type

