### PR TITLE
filestore: Fix `.info` file not deleted if the binary file was successfully deleted

### DIFF
--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -207,12 +207,12 @@ func (upload *fileUpload) Terminate(ctx context.Context) error {
 	// to delete them anyways. The files might be removed by a cron job for cleaning up
 	// or some file might have been removed when tusd crashed during the termination.
 	err := os.Remove(upload.binPath)
-	if !errors.Is(err, os.ErrNotExist) {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
 	err = os.Remove(upload.infoPath)
-	if !errors.Is(err, os.ErrNotExist) {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 


### PR DESCRIPTION
This PR fixes a bug where if the bin file was deleted without errors in the filestore, the `.info` file would not be deleted.

The main issue is that the `!errors.Is(err, os.ErrNotExist)` check is being made without checking that `err` is actually not `nil`. The `nil` value will pass this `if` case and the subsequent cleanup of `.info` file will not happen in that case because the function returns at that point.

I checked the fix in my setup and now it actually removes the `.info` file as well.