### PR TITLE
s3store: Pass Content-Type from `filetype` metadata field to S3

### DIFF
--- a/docs/_storage-backends/aws-s3.md
+++ b/docs/_storage-backends/aws-s3.md
@@ -89,6 +89,8 @@ If [metadata](https://tus.io/protocols/resumable-upload#upload-metadata) is asso
 
 In addition, the metadata is also stored in the informational object, which can be used to retrieve the original metadata without any characters being replaced.
 
+If the metadata contains a `filetype` key, its value is used to set the `Content-Type` header of the file object. Setting the `Content-Disposition` or `Content-Encoding` headers is not yet supported.
+
 ## Considerations
 
 When receiving a `PATCH` request, parts of its body will be temporarily stored on disk before they can be transferred to S3. This is necessary to meet the minimum part size for an S3 multipart upload enforced by S3 and to allow the AWS SDK to calculate a checksum. Once the part has been uploaded to S3, the temporary file will be removed immediately. Therefore, please ensure that the server running this storage backend has enough disk space available to hold these temporary files.

--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -326,11 +326,15 @@ func (store S3Store) NewUpload(ctx context.Context, info handler.FileInfo) (hand
 
 	// Create the actual multipart upload
 	t := time.Now()
-	res, err := store.Service.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
+	multipartUploadInput := &s3.CreateMultipartUploadInput{
 		Bucket:   aws.String(store.Bucket),
 		Key:      store.keyWithPrefix(objectId),
 		Metadata: metadata,
-	})
+	}
+	if contentType, found := info.MetaData["contentType"]; found {
+		multipartUploadInput.ContentType = aws.String(contentType)
+	}
+	res, err := store.Service.CreateMultipartUpload(ctx, multipartUploadInput)
 	store.observeRequestDuration(t, metricCreateMultipartUpload)
 	if err != nil {
 		return nil, fmt.Errorf("s3store: unable to create multipart upload:\n%s", err)

--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -331,9 +331,7 @@ func (store S3Store) NewUpload(ctx context.Context, info handler.FileInfo) (hand
 		Key:      store.keyWithPrefix(objectId),
 		Metadata: metadata,
 	}
-	if contentType, found := info.MetaData["contentType"]; found {
-		multipartUploadInput.ContentType = aws.String(contentType)
-	} else if fileType, found := info.MetaData["filetype"]; found {
+	if fileType, found := info.MetaData["filetype"]; found {
 		multipartUploadInput.ContentType = aws.String(fileType)
 	}
 	res, err := store.Service.CreateMultipartUpload(ctx, multipartUploadInput)

--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -333,6 +333,8 @@ func (store S3Store) NewUpload(ctx context.Context, info handler.FileInfo) (hand
 	}
 	if contentType, found := info.MetaData["contentType"]; found {
 		multipartUploadInput.ContentType = aws.String(contentType)
+	} else if fileType, found := info.MetaData["filetype"]; found {
+		multipartUploadInput.ContentType = aws.String(fileType)
 	}
 	res, err := store.Service.CreateMultipartUpload(ctx, multipartUploadInput)
 	store.observeRequestDuration(t, metricCreateMultipartUpload)

--- a/pkg/s3store/s3store_test.go
+++ b/pkg/s3store/s3store_test.go
@@ -164,6 +164,53 @@ func TestNewUploadWithMetadataObjectPrefix(t *testing.T) {
 	assert.NotNil(upload)
 }
 
+func TestNewUploadWithContentType(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	assert := assert.New(t)
+
+	s3obj := NewMockS3API(mockCtrl)
+	store := New("bucket", s3obj)
+
+	assert.Equal("bucket", store.Bucket)
+	assert.Equal(s3obj, store.Service)
+
+	gomock.InOrder(
+		s3obj.EXPECT().CreateMultipartUpload(context.Background(), &s3.CreateMultipartUploadInput{
+			Bucket:      aws.String("bucket"),
+			Key:         aws.String("uploadId"),
+			ContentType: aws.String("application/pdf"),
+			Metadata: map[string]string{
+				"foo":         "hello",
+				"bar":         "men???hi",
+				"contentType": "application/pdf",
+			},
+		}).Return(&s3.CreateMultipartUploadOutput{
+			UploadId: aws.String("multipartId"),
+		}, nil),
+		s3obj.EXPECT().PutObject(context.Background(), &s3.PutObjectInput{
+			Bucket:        aws.String("bucket"),
+			Key:           aws.String("uploadId.info"),
+			Body:          bytes.NewReader([]byte(`{"ID":"uploadId+multipartId","Size":500,"SizeIsDeferred":false,"Offset":0,"MetaData":{"bar":"menü\r\nhi","contentType":"application/pdf","foo":"hello"},"IsPartial":false,"IsFinal":false,"PartialUploads":null,"Storage":{"Bucket":"bucket","Key":"uploadId","Type":"s3store"}}`)),
+			ContentLength: aws.Int64(273),
+		}),
+	)
+
+	info := handler.FileInfo{
+		ID:   "uploadId",
+		Size: 500,
+		MetaData: map[string]string{
+			"foo":         "hello",
+			"bar":         "menü\r\nhi",
+			"contentType": "application/pdf",
+		},
+	}
+
+	upload, err := store.NewUpload(context.Background(), info)
+	assert.Nil(err)
+	assert.NotNil(upload)
+}
+
 // This test ensures that an newly created upload without any chunks can be
 // directly finished. There are no calls to ListPart or HeadObject because
 // the upload is not fetched from S3 first.

--- a/pkg/s3store/s3store_test.go
+++ b/pkg/s3store/s3store_test.go
@@ -45,17 +45,19 @@ func TestNewUpload(t *testing.T) {
 			Bucket: aws.String("bucket"),
 			Key:    aws.String("uploadId"),
 			Metadata: map[string]string{
-				"foo": "hello",
-				"bar": "men???hi",
+				"foo":      "hello",
+				"bar":      "men???hi",
+				"filetype": "application/pdf",
 			},
+			ContentType: aws.String("application/pdf"),
 		}).Return(&s3.CreateMultipartUploadOutput{
 			UploadId: aws.String("multipartId"),
 		}, nil),
 		s3obj.EXPECT().PutObject(context.Background(), &s3.PutObjectInput{
 			Bucket:        aws.String("bucket"),
 			Key:           aws.String("uploadId.info"),
-			Body:          bytes.NewReader([]byte(`{"ID":"uploadId+multipartId","Size":500,"SizeIsDeferred":false,"Offset":0,"MetaData":{"bar":"menü\r\nhi","foo":"hello"},"IsPartial":false,"IsFinal":false,"PartialUploads":null,"Storage":{"Bucket":"bucket","Key":"uploadId","Type":"s3store"}}`)),
-			ContentLength: aws.Int64(241),
+			Body:          bytes.NewReader([]byte(`{"ID":"uploadId+multipartId","Size":500,"SizeIsDeferred":false,"Offset":0,"MetaData":{"bar":"menü\r\nhi","filetype":"application/pdf","foo":"hello"},"IsPartial":false,"IsFinal":false,"PartialUploads":null,"Storage":{"Bucket":"bucket","Key":"uploadId","Type":"s3store"}}`)),
+			ContentLength: aws.Int64(270),
 		}),
 	)
 
@@ -63,8 +65,9 @@ func TestNewUpload(t *testing.T) {
 		ID:   "uploadId",
 		Size: 500,
 		MetaData: map[string]string{
-			"foo": "hello",
-			"bar": "menü\r\nhi",
+			"foo":      "hello",
+			"bar":      "menü\r\nhi",
+			"filetype": "application/pdf",
 		},
 	}
 
@@ -156,53 +159,6 @@ func TestNewUploadWithMetadataObjectPrefix(t *testing.T) {
 		MetaData: map[string]string{
 			"foo": "hello",
 			"bar": "menü",
-		},
-	}
-
-	upload, err := store.NewUpload(context.Background(), info)
-	assert.Nil(err)
-	assert.NotNil(upload)
-}
-
-func TestNewUploadWithFileType(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	assert := assert.New(t)
-
-	s3obj := NewMockS3API(mockCtrl)
-	store := New("bucket", s3obj)
-
-	assert.Equal("bucket", store.Bucket)
-	assert.Equal(s3obj, store.Service)
-
-	gomock.InOrder(
-		s3obj.EXPECT().CreateMultipartUpload(context.Background(), &s3.CreateMultipartUploadInput{
-			Bucket:      aws.String("bucket"),
-			Key:         aws.String("uploadId"),
-			ContentType: aws.String("application/pdf"),
-			Metadata: map[string]string{
-				"foo":      "hello",
-				"bar":      "men???hi",
-				"filetype": "application/pdf",
-			},
-		}).Return(&s3.CreateMultipartUploadOutput{
-			UploadId: aws.String("multipartId"),
-		}, nil),
-		s3obj.EXPECT().PutObject(context.Background(), &s3.PutObjectInput{
-			Bucket:        aws.String("bucket"),
-			Key:           aws.String("uploadId.info"),
-			Body:          bytes.NewReader([]byte(`{"ID":"uploadId+multipartId","Size":500,"SizeIsDeferred":false,"Offset":0,"MetaData":{"bar":"menü\r\nhi","filetype":"application/pdf","foo":"hello"},"IsPartial":false,"IsFinal":false,"PartialUploads":null,"Storage":{"Bucket":"bucket","Key":"uploadId","Type":"s3store"}}`)),
-			ContentLength: aws.Int64(270),
-		}),
-	)
-
-	info := handler.FileInfo{
-		ID:   "uploadId",
-		Size: 500,
-		MetaData: map[string]string{
-			"foo":      "hello",
-			"bar":      "menü\r\nhi",
-			"filetype": "application/pdf",
 		},
 	}
 

--- a/pkg/s3store/s3store_test.go
+++ b/pkg/s3store/s3store_test.go
@@ -211,6 +211,53 @@ func TestNewUploadWithContentType(t *testing.T) {
 	assert.NotNil(upload)
 }
 
+func TestNewUploadWithFileType(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	assert := assert.New(t)
+
+	s3obj := NewMockS3API(mockCtrl)
+	store := New("bucket", s3obj)
+
+	assert.Equal("bucket", store.Bucket)
+	assert.Equal(s3obj, store.Service)
+
+	gomock.InOrder(
+		s3obj.EXPECT().CreateMultipartUpload(context.Background(), &s3.CreateMultipartUploadInput{
+			Bucket:      aws.String("bucket"),
+			Key:         aws.String("uploadId"),
+			ContentType: aws.String("application/pdf"),
+			Metadata: map[string]string{
+				"foo":      "hello",
+				"bar":      "men???hi",
+				"filetype": "application/pdf",
+			},
+		}).Return(&s3.CreateMultipartUploadOutput{
+			UploadId: aws.String("multipartId"),
+		}, nil),
+		s3obj.EXPECT().PutObject(context.Background(), &s3.PutObjectInput{
+			Bucket:        aws.String("bucket"),
+			Key:           aws.String("uploadId.info"),
+			Body:          bytes.NewReader([]byte(`{"ID":"uploadId+multipartId","Size":500,"SizeIsDeferred":false,"Offset":0,"MetaData":{"bar":"menü\r\nhi","filetype":"application/pdf","foo":"hello"},"IsPartial":false,"IsFinal":false,"PartialUploads":null,"Storage":{"Bucket":"bucket","Key":"uploadId","Type":"s3store"}}`)),
+			ContentLength: aws.Int64(270),
+		}),
+	)
+
+	info := handler.FileInfo{
+		ID:   "uploadId",
+		Size: 500,
+		MetaData: map[string]string{
+			"foo":      "hello",
+			"bar":      "menü\r\nhi",
+			"filetype": "application/pdf",
+		},
+	}
+
+	upload, err := store.NewUpload(context.Background(), info)
+	assert.Nil(err)
+	assert.NotNil(upload)
+}
+
 // This test ensures that an newly created upload without any chunks can be
 // directly finished. There are no calls to ListPart or HeadObject because
 // the upload is not fetched from S3 first.


### PR DESCRIPTION
After this PR, if the client passes a `contentType` value in the `metadata` object, the resulting file on S3 will be created with the value passed.

This change causes tusd for Go to match the NodeJS version's behavior, discussed here: https://stackoverflow.com/questions/74148196/how-to-resolve-application-octet-stream-in-s3-using-tus-node-tusd-uppy-or-net.