### PR TITLE
cli: Add `show-startup-logs` flag to reduce startup log verbosity

### DIFF
--- a/cmd/tusd/cli/composer.go
+++ b/cmd/tusd/cli/composer.go
@@ -37,12 +37,12 @@ func CreateComposer() {
 
 		if Flags.S3Endpoint == "" {
 			if Flags.S3TransferAcceleration {
-				printStartupLogLine("Using 's3://%s' as S3 bucket for storage with AWS S3 Transfer Acceleration enabled.\n", Flags.S3Bucket)
+				printStartupLog("Using 's3://%s' as S3 bucket for storage with AWS S3 Transfer Acceleration enabled.\n", Flags.S3Bucket)
 			} else {
-				printStartupLogLine("Using 's3://%s' as S3 bucket for storage.\n", Flags.S3Bucket)
+				printStartupLog("Using 's3://%s' as S3 bucket for storage.\n", Flags.S3Bucket)
 			}
 		} else {
-			printStartupLogLine("Using '%s/%s' as S3 endpoint and bucket for storage.\n", Flags.S3Endpoint, Flags.S3Bucket)
+			printStartupLog("Using '%s/%s' as S3 endpoint and bucket for storage.\n", Flags.S3Endpoint, Flags.S3Bucket)
 		}
 
 		s3Client := s3.NewFromConfig(s3Config, func(o *s3.Options) {
@@ -85,7 +85,8 @@ func CreateComposer() {
 		if err != nil {
 			stderr.Fatalf("Unable to create Google Cloud Storage service: %s\n", err)
 		}
-		printStartupLogLine("Using 'gcs://%s' as GCS bucket for storage.\n", Flags.GCSBucket)
+
+		printStartupLog("Using 'gcs://%s' as GCS bucket for storage.\n", Flags.GCSBucket)
 
 		store := gcsstore.New(Flags.GCSBucket, service)
 		store.ObjectPrefix = Flags.GCSObjectPrefix
@@ -111,7 +112,7 @@ func CreateComposer() {
 		if azureEndpoint == "" {
 			azureEndpoint = fmt.Sprintf("https://%s.blob.core.windows.net", accountName)
 		}
-		printStartupLogLine("Using Azure endpoint %s.\n", azureEndpoint)
+		printStartupLog("Using Azure endpoint %s.\n", azureEndpoint)
 
 		azConfig := &azurestore.AzConfig{
 			AccountName:         accountName,
@@ -139,7 +140,9 @@ func CreateComposer() {
 		if err != nil {
 			stderr.Fatalf("Unable to make absolute path: %s", err)
 		}
-		printStartupLogLine("Using '%s' as directory storage.\n", dir)
+
+		printStartupLog("Using '%s' as directory storage.\n", dir)
+
 		if err := os.MkdirAll(dir, os.FileMode(0774)); err != nil {
 			stderr.Fatalf("Unable to ensure directory exists: %s", err)
 		}
@@ -152,5 +155,6 @@ func CreateComposer() {
 		locker.HolderPollInterval = Flags.FilelockHolderPollInterval
 		locker.UseIn(Composer)
 	}
-	printStartupLogLine("Using %.2fMB as maximum size.\n", float64(Flags.MaxSize)/1024/1024)
+
+	printStartupLog("Using %.2fMB as maximum size.\n", float64(Flags.MaxSize)/1024/1024)
 }

--- a/cmd/tusd/cli/composer.go
+++ b/cmd/tusd/cli/composer.go
@@ -37,12 +37,12 @@ func CreateComposer() {
 
 		if Flags.S3Endpoint == "" {
 			if Flags.S3TransferAcceleration {
-				stdout.Printf("Using 's3://%s' as S3 bucket for storage with AWS S3 Transfer Acceleration enabled.\n", Flags.S3Bucket)
+				printStartupLogLine("Using 's3://%s' as S3 bucket for storage with AWS S3 Transfer Acceleration enabled.\n", Flags.S3Bucket)
 			} else {
-				stdout.Printf("Using 's3://%s' as S3 bucket for storage.\n", Flags.S3Bucket)
+				printStartupLogLine("Using 's3://%s' as S3 bucket for storage.\n", Flags.S3Bucket)
 			}
 		} else {
-			stdout.Printf("Using '%s/%s' as S3 endpoint and bucket for storage.\n", Flags.S3Endpoint, Flags.S3Bucket)
+			printStartupLogLine("Using '%s/%s' as S3 endpoint and bucket for storage.\n", Flags.S3Endpoint, Flags.S3Bucket)
 		}
 
 		s3Client := s3.NewFromConfig(s3Config, func(o *s3.Options) {
@@ -85,8 +85,7 @@ func CreateComposer() {
 		if err != nil {
 			stderr.Fatalf("Unable to create Google Cloud Storage service: %s\n", err)
 		}
-
-		stdout.Printf("Using 'gcs://%s' as GCS bucket for storage.\n", Flags.GCSBucket)
+		printStartupLogLine("Using 'gcs://%s' as GCS bucket for storage.\n", Flags.GCSBucket)
 
 		store := gcsstore.New(Flags.GCSBucket, service)
 		store.ObjectPrefix = Flags.GCSObjectPrefix
@@ -112,7 +111,7 @@ func CreateComposer() {
 		if azureEndpoint == "" {
 			azureEndpoint = fmt.Sprintf("https://%s.blob.core.windows.net", accountName)
 		}
-		stdout.Printf("Using Azure endpoint %s.\n", azureEndpoint)
+		printStartupLogLine("Using Azure endpoint %s.\n", azureEndpoint)
 
 		azConfig := &azurestore.AzConfig{
 			AccountName:         accountName,
@@ -140,8 +139,7 @@ func CreateComposer() {
 		if err != nil {
 			stderr.Fatalf("Unable to make absolute path: %s", err)
 		}
-
-		stdout.Printf("Using '%s' as directory storage.\n", dir)
+		printStartupLogLine("Using '%s' as directory storage.\n", dir)
 		if err := os.MkdirAll(dir, os.FileMode(0774)); err != nil {
 			stderr.Fatalf("Unable to ensure directory exists: %s", err)
 		}
@@ -154,6 +152,5 @@ func CreateComposer() {
 		locker.HolderPollInterval = Flags.FilelockHolderPollInterval
 		locker.UseIn(Composer)
 	}
-
-	stdout.Printf("Using %.2fMB as maximum size.\n", float64(Flags.MaxSize)/1024/1024)
+	printStartupLogLine("Using %.2fMB as maximum size.\n", float64(Flags.MaxSize)/1024/1024)
 }

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -191,10 +191,10 @@ func ParseFlags() {
 		f.StringVar(&Flags.PprofPath, "pprof-path", "/debug/pprof/", "Path under which the pprof endpoint will be accessible")
 		f.IntVar(&Flags.PprofBlockProfileRate, "pprof-block-profile-rate", 0, "Fraction of goroutine blocking events that are reported in the blocking profile")
 		f.IntVar(&Flags.PprofMutexProfileRate, "pprof-mutex-profile-rate", 0, "Fraction of mutex contention events that are reported in the mutex profile")
-		f.BoolVar(&Flags.ShowGreeting, "show-greeting", true, "Show the greeting message")
+		f.BoolVar(&Flags.ShowGreeting, "show-greeting", true, "Show the greeting message for GET requests to the root path")
 		f.BoolVar(&Flags.ShowVersion, "version", false, "Print tusd version information")
 		f.BoolVar(&Flags.VerboseOutput, "verbose", true, "Enable verbose logging output")
-		f.BoolVar(&Flags.ShowStartupLogs, "show-startup-logs", true, "Show the startup logs")
+		f.BoolVar(&Flags.ShowStartupLogs, "show-startup-logs", true, "Print details about tusd's configuration during startup")
 		f.StringVar(&Flags.LogFormat, "log-format", "text", "Logging format (text or json)")
 	})
 

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -72,6 +72,7 @@ var Flags struct {
 	PprofMutexProfileRate            int
 	BehindProxy                      bool
 	VerboseOutput                    bool
+	ShowStartupLogs                  bool
 	LogFormat                        string
 	S3TransferAcceleration           bool
 	TLSCertFile                      string
@@ -193,6 +194,7 @@ func ParseFlags() {
 		f.BoolVar(&Flags.ShowGreeting, "show-greeting", true, "Show the greeting message")
 		f.BoolVar(&Flags.ShowVersion, "version", false, "Print tusd version information")
 		f.BoolVar(&Flags.VerboseOutput, "verbose", true, "Enable verbose logging output")
+		f.BoolVar(&Flags.ShowStartupLogs, "show-startup-logs", true, "Show the startup logs")
 		f.StringVar(&Flags.LogFormat, "log-format", "text", "Logging format (text or json)")
 	})
 

--- a/cmd/tusd/cli/hooks.go
+++ b/cmd/tusd/cli/hooks.go
@@ -13,13 +13,13 @@ import (
 
 func getHookHandler(config *handler.Config) hooks.HookHandler {
 	if Flags.FileHooksDir != "" {
-		printStartupLogLine("Using '%s' for hooks", Flags.FileHooksDir)
+		printStartupLog("Using '%s' for hooks", Flags.FileHooksDir)
 
 		return &file.FileHook{
 			Directory: Flags.FileHooksDir,
 		}
 	} else if Flags.HttpHooksEndpoint != "" {
-		printStartupLogLine("Using '%s' as the endpoint for hooks", Flags.HttpHooksEndpoint)
+		printStartupLog("Using '%s' as the endpoint for hooks", Flags.HttpHooksEndpoint)
 
 		return &http.HttpHook{
 			Endpoint:       Flags.HttpHooksEndpoint,
@@ -28,7 +28,7 @@ func getHookHandler(config *handler.Config) hooks.HookHandler {
 			ForwardHeaders: strings.Split(Flags.HttpHooksForwardHeaders, ","),
 		}
 	} else if Flags.GrpcHooksEndpoint != "" {
-		printStartupLogLine("Using '%s' as the endpoint for gRPC hooks", Flags.GrpcHooksEndpoint)
+		printStartupLog("Using '%s' as the endpoint for gRPC hooks", Flags.GrpcHooksEndpoint)
 
 		return &grpc.GrpcHook{
 			Endpoint:                        Flags.GrpcHooksEndpoint,
@@ -41,7 +41,7 @@ func getHookHandler(config *handler.Config) hooks.HookHandler {
 			ForwardHeaders:                  strings.Split(Flags.GrpcHooksForwardHeaders, ","),
 		}
 	} else if Flags.PluginHookPath != "" {
-		printStartupLogLine("Using '%s' to load plugin for hooks", Flags.PluginHookPath)
+		printStartupLog("Using '%s' to load plugin for hooks", Flags.PluginHookPath)
 
 		return &plugin.PluginHook{
 			Path:          Flags.PluginHookPath,

--- a/cmd/tusd/cli/hooks.go
+++ b/cmd/tusd/cli/hooks.go
@@ -13,13 +13,13 @@ import (
 
 func getHookHandler(config *handler.Config) hooks.HookHandler {
 	if Flags.FileHooksDir != "" {
-		stdout.Printf("Using '%s' for hooks", Flags.FileHooksDir)
+		printStartupLogLine("Using '%s' for hooks", Flags.FileHooksDir)
 
 		return &file.FileHook{
 			Directory: Flags.FileHooksDir,
 		}
 	} else if Flags.HttpHooksEndpoint != "" {
-		stdout.Printf("Using '%s' as the endpoint for hooks", Flags.HttpHooksEndpoint)
+		printStartupLogLine("Using '%s' as the endpoint for hooks", Flags.HttpHooksEndpoint)
 
 		return &http.HttpHook{
 			Endpoint:       Flags.HttpHooksEndpoint,
@@ -28,7 +28,7 @@ func getHookHandler(config *handler.Config) hooks.HookHandler {
 			ForwardHeaders: strings.Split(Flags.HttpHooksForwardHeaders, ","),
 		}
 	} else if Flags.GrpcHooksEndpoint != "" {
-		stdout.Printf("Using '%s' as the endpoint for gRPC hooks", Flags.GrpcHooksEndpoint)
+		printStartupLogLine("Using '%s' as the endpoint for gRPC hooks", Flags.GrpcHooksEndpoint)
 
 		return &grpc.GrpcHook{
 			Endpoint:                        Flags.GrpcHooksEndpoint,
@@ -41,7 +41,7 @@ func getHookHandler(config *handler.Config) hooks.HookHandler {
 			ForwardHeaders:                  strings.Split(Flags.GrpcHooksForwardHeaders, ","),
 		}
 	} else if Flags.PluginHookPath != "" {
-		stdout.Printf("Using '%s' to load plugin for hooks", Flags.PluginHookPath)
+		printStartupLogLine("Using '%s' to load plugin for hooks", Flags.PluginHookPath)
 
 		return &plugin.PluginHook{
 			Path:          Flags.PluginHookPath,

--- a/cmd/tusd/cli/log.go
+++ b/cmd/tusd/cli/log.go
@@ -15,7 +15,6 @@ func SetupStructuredLogger() {
 	if Flags.VerboseOutput {
 		level = slog.LevelDebug
 	}
-
 	replaceAttrFunc := func(groups []string, a slog.Attr) slog.Attr {
 		// Remove time attribute, because that is handled by the logger
 		if a.Key == slog.TimeKey {
@@ -59,4 +58,11 @@ type logWriter struct {
 func (l logWriter) Write(msg []byte) (int, error) {
 	l.logger.Print(string(msg))
 	return len(msg), nil
+}
+
+func printStartupLogLine(msg string, args ...interface{}) {
+	// Check if the flag allows startup logs
+	if Flags.ShowStartupLogs {
+		stdout.Printf("[STARTUP] "+msg, args...)
+	}
 }

--- a/cmd/tusd/cli/log.go
+++ b/cmd/tusd/cli/log.go
@@ -15,6 +15,7 @@ func SetupStructuredLogger() {
 	if Flags.VerboseOutput {
 		level = slog.LevelDebug
 	}
+
 	replaceAttrFunc := func(groups []string, a slog.Attr) slog.Attr {
 		// Remove time attribute, because that is handled by the logger
 		if a.Key == slog.TimeKey {
@@ -60,9 +61,10 @@ func (l logWriter) Write(msg []byte) (int, error) {
 	return len(msg), nil
 }
 
-func printStartupLogLine(msg string, args ...interface{}) {
-	// Check if the flag allows startup logs
-	if Flags.ShowStartupLogs {
-		stdout.Printf("[STARTUP] "+msg, args...)
+func printStartupLog(msg string, args ...interface{}) {
+	if !Flags.ShowStartupLogs {
+		return
 	}
+
+	stdout.Printf(msg, args...)
 }

--- a/cmd/tusd/cli/metrics.go
+++ b/cmd/tusd/cli/metrics.go
@@ -22,6 +22,6 @@ func SetupMetrics(mux *http.ServeMux, handler *handler.Handler) {
 	prometheus.MustRegister(hooks.MetricsHookInvocationsTotal)
 	prometheus.MustRegister(prometheuscollector.New(handler.Metrics))
 
-	stdout.Printf("Using %s as the metrics path.\n", Flags.MetricsPath)
+	printStartupLogLine("Using %s as the metrics path.\n", Flags.MetricsPath)
 	mux.Handle(Flags.MetricsPath, promhttp.Handler())
 }

--- a/cmd/tusd/cli/metrics.go
+++ b/cmd/tusd/cli/metrics.go
@@ -22,6 +22,6 @@ func SetupMetrics(mux *http.ServeMux, handler *handler.Handler) {
 	prometheus.MustRegister(hooks.MetricsHookInvocationsTotal)
 	prometheus.MustRegister(prometheuscollector.New(handler.Metrics))
 
-	printStartupLogLine("Using %s as the metrics path.\n", Flags.MetricsPath)
+	printStartupLog("Using %s as the metrics path.\n", Flags.MetricsPath)
 	mux.Handle(Flags.MetricsPath, promhttp.Handler())
 }

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -58,8 +58,7 @@ func Serve() {
 		for _, h := range Flags.EnabledHooks {
 			enabledHooksString = append(enabledHooksString, string(h))
 		}
-
-		stdout.Printf("Enabled hook events: %s", strings.Join(enabledHooksString, ", "))
+		printStartupLogLine("Enabled hook events: %s", strings.Join(enabledHooksString, ", "))
 
 	} else {
 		handler, err = tushandler.NewHandler(config)
@@ -67,22 +66,19 @@ func Serve() {
 	if err != nil {
 		stderr.Fatalf("Unable to create handler: %s", err)
 	}
-
-	stdout.Printf("Supported tus extensions: %s\n", handler.SupportedExtensions())
+	printStartupLogLine("Supported tus extensions: %s\n", handler.SupportedExtensions())
 
 	basepath := Flags.Basepath
 	address := ""
 
 	if Flags.HttpSock != "" {
 		address = Flags.HttpSock
-		stdout.Printf("Using %s as socket to listen.\n", address)
+		printStartupLogLine("Using %s as socket to listen.\n", address)
 	} else {
 		address = Flags.HttpHost + ":" + Flags.HttpPort
-		stdout.Printf("Using %s as address to listen.\n", address)
+		printStartupLogLine("Using %s as address to listen.\n", address)
 	}
-
-	stdout.Printf("Using %s as the base path.\n", basepath)
-
+	printStartupLogLine("Using %s as the base path.\n", basepath)
 	mux := http.NewServeMux()
 	if basepath == "/" {
 		// If the basepath is set to the root path, only install the tusd handler

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -58,7 +58,8 @@ func Serve() {
 		for _, h := range Flags.EnabledHooks {
 			enabledHooksString = append(enabledHooksString, string(h))
 		}
-		printStartupLogLine("Enabled hook events: %s", strings.Join(enabledHooksString, ", "))
+
+		printStartupLog("Enabled hook events: %s", strings.Join(enabledHooksString, ", "))
 
 	} else {
 		handler, err = tushandler.NewHandler(config)
@@ -66,19 +67,22 @@ func Serve() {
 	if err != nil {
 		stderr.Fatalf("Unable to create handler: %s", err)
 	}
-	printStartupLogLine("Supported tus extensions: %s\n", handler.SupportedExtensions())
+
+	printStartupLog("Supported tus extensions: %s\n", handler.SupportedExtensions())
 
 	basepath := Flags.Basepath
 	address := ""
 
 	if Flags.HttpSock != "" {
 		address = Flags.HttpSock
-		printStartupLogLine("Using %s as socket to listen.\n", address)
+		printStartupLog("Using %s as socket to listen.\n", address)
 	} else {
 		address = Flags.HttpHost + ":" + Flags.HttpPort
-		printStartupLogLine("Using %s as address to listen.\n", address)
+		printStartupLog("Using %s as address to listen.\n", address)
 	}
-	printStartupLogLine("Using %s as the base path.\n", basepath)
+
+	printStartupLog("Using %s as the base path.\n", basepath)
+
 	mux := http.NewServeMux()
 	if basepath == "/" {
 		// If the basepath is set to the root path, only install the tusd handler
@@ -125,7 +129,7 @@ func Serve() {
 	}
 
 	if Flags.HttpSock == "" {
-		stdout.Printf("You can now upload files to: %s://%s%s", protocol, listener.Addr(), basepath)
+		printStartupLog("You can now upload files to: %s://%s%s", protocol, listener.Addr(), basepath)
 	}
 
 	serverCtx, cancelServerCtx := context.WithCancelCause(context.Background())


### PR DESCRIPTION
This enables the user to enable or disable the startup logs while starting the tusd server. It helps the user suppress the startup logs as per their preference.

The flag has a default value of true.
Fixes #1216.

Before:
![image](https://github.com/user-attachments/assets/70a9f826-2996-4838-a058-52e4e1ac9618)

<hr/>
After:

**set as false:**

![image](https://github.com/user-attachments/assets/1617196d-05ea-4657-988f-85eeb05c1dd5)

**set as true explicity:**
![image](https://github.com/user-attachments/assets/89d29d85-86da-4245-a871-cb76374dd52b)

**default:**
![image](https://github.com/user-attachments/assets/5f32de99-517f-43dc-9ee8-921e8abfed5e)

