### PR TITLE
chore: update S3 storage to support Content-Disposition header

### DIFF
--- a/docs/_storage-backends/aws-s3.md
+++ b/docs/_storage-backends/aws-s3.md
@@ -70,7 +70,7 @@ Uploads on S3 are stored using multiple objects:
 
 - An informational object with the `.info` extension holds meta information about the uploads, as described in [the section for all storage backends]({{ site.baseurl }}/storage-backends/overview/#storage-format).
 - An [S3 multipart upload](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html) is used to transfer the file piece-by-piece to S3 and reassemble the original file once the upload is finished. It is removed once the upload is finished.
-- A file object will contain the uploaded file. It will only be created once the entire upload is finished. 
+- A file object will contain the uploaded file. It will only be created once the entire upload is finished.
 - A temporary object with the `.part` extension may be created when the upload has been paused to store some temporary data which cannot be transferred to the S3 multipart upload due to its small size. Once the upload is resumed, the temporary object will be gone.
 
 By default, the objects are stored at the root of the bucket. For example the objects for the upload ID `abcdef123` will be:
@@ -89,7 +89,7 @@ If [metadata](https://tus.io/protocols/resumable-upload#upload-metadata) is asso
 
 In addition, the metadata is also stored in the informational object, which can be used to retrieve the original metadata without any characters being replaced.
 
-If the metadata contains a `filetype` key, its value is used to set the `Content-Type` header of the file object. Setting the `Content-Disposition` or `Content-Encoding` headers is not yet supported.
+If the metadata contains a `filetype` key, its value is used to set the `Content-Type` and `Content-Disposition` headers of the file object. Setting the `Content-Encoding` header is not yet supported.
 
 ## Considerations
 

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -1047,7 +1047,7 @@ func (handler *UnroutedHandler) GetFile(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	contentType, contentDisposition := filterContentType(info)
+	contentType, contentDisposition := FilterContentType(info)
 	resp := HTTPResponse{
 		StatusCode: http.StatusOK,
 		Header: HTTPHeader{
@@ -1104,13 +1104,13 @@ var mimeInlineBrowserWhitelist = map[string]struct{}{
 	"application/ogg": {},
 }
 
-// filterContentType returns the values for the Content-Type and
+// FilterContentType returns the values for the Content-Type and
 // Content-Disposition headers for a given upload. These values should be used
 // in responses for GET requests to ensure that only non-malicious file types
 // are shown directly in the browser. It will extract the file name and type
-// from the "fileame" and "filetype".
+// from the "filename" and "filetype".
 // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
-func filterContentType(info FileInfo) (contentType string, contentDisposition string) {
+func FilterContentType(info FileInfo) (contentType string, contentDisposition string) {
 	filetype := info.MetaData["filetype"]
 
 	if reMimeType.MatchString(filetype) {

--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -331,8 +331,10 @@ func (store S3Store) NewUpload(ctx context.Context, info handler.FileInfo) (hand
 		Key:      store.keyWithPrefix(objectId),
 		Metadata: metadata,
 	}
-	if fileType, found := info.MetaData["filetype"]; found {
-		multipartUploadInput.ContentType = aws.String(fileType)
+	if _, found := info.MetaData["filetype"]; found {
+		contentType, contentDisposition := handler.FilterContentType(info)
+		multipartUploadInput.ContentType = aws.String(contentType)
+		multipartUploadInput.ContentDisposition = aws.String(contentDisposition)
 	}
 	res, err := store.Service.CreateMultipartUpload(ctx, multipartUploadInput)
 	store.observeRequestDuration(t, metricCreateMultipartUpload)

--- a/pkg/s3store/s3store_test.go
+++ b/pkg/s3store/s3store_test.go
@@ -47,17 +47,19 @@ func TestNewUpload(t *testing.T) {
 			Metadata: map[string]string{
 				"foo":      "hello",
 				"bar":      "men???hi",
+				"filename": "hello.pdf",
 				"filetype": "application/pdf",
 			},
-			ContentType: aws.String("application/pdf"),
+			ContentType:        aws.String("application/pdf"),
+			ContentDisposition: aws.String("attachment;filename=\"hello.pdf\""),
 		}).Return(&s3.CreateMultipartUploadOutput{
 			UploadId: aws.String("multipartId"),
 		}, nil),
 		s3obj.EXPECT().PutObject(context.Background(), &s3.PutObjectInput{
 			Bucket:        aws.String("bucket"),
 			Key:           aws.String("uploadId.info"),
-			Body:          bytes.NewReader([]byte(`{"ID":"uploadId+multipartId","Size":500,"SizeIsDeferred":false,"Offset":0,"MetaData":{"bar":"menü\r\nhi","filetype":"application/pdf","foo":"hello"},"IsPartial":false,"IsFinal":false,"PartialUploads":null,"Storage":{"Bucket":"bucket","Key":"uploadId","Type":"s3store"}}`)),
-			ContentLength: aws.Int64(270),
+			Body:          bytes.NewReader([]byte(`{"ID":"uploadId+multipartId","Size":500,"SizeIsDeferred":false,"Offset":0,"MetaData":{"bar":"menü\r\nhi","filename":"hello.pdf","filetype":"application/pdf","foo":"hello"},"IsPartial":false,"IsFinal":false,"PartialUploads":null,"Storage":{"Bucket":"bucket","Key":"uploadId","Type":"s3store"}}`)),
+			ContentLength: aws.Int64(293),
 		}),
 	)
 
@@ -67,6 +69,7 @@ func TestNewUpload(t *testing.T) {
 		MetaData: map[string]string{
 			"foo":      "hello",
 			"bar":      "menü\r\nhi",
+			"filename": "hello.pdf",
 			"filetype": "application/pdf",
 		},
 	}


### PR DESCRIPTION
- Add `Content-Disposition` header support in S3 uploads
- Rename `filterContentType` to `FilterContentType` (export)
- Update test cases for new header support
- Correct typo in function documentation
- Adjust metadata handling in S3Store uploads