### PR TITLE
handler: Remove default ports in Location headers

### DIFF
--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -57,11 +57,11 @@ server {
         proxy_http_version       1.1;
 
         # Add X-Forwarded-* headers
-        proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
 
         proxy_set_header         Upgrade $http_upgrade;
         proxy_set_header         Connection "upgrade";
         client_max_body_size     0;
+            proxy_set_header X-Forwarded-Host $host:$server_port;
     }
 }

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -1323,6 +1323,14 @@ func getHostAndProtocol(r *http.Request, allowForwarded bool) (host, proto strin
 		}
 	}
 
+	// Remove default ports
+	if proto == "http" {
+		host = strings.TrimSuffix(host, ":80")
+	}
+	if proto == "https" {
+		host = strings.TrimSuffix(host, ":443")
+	}
+
 	return
 }
 


### PR DESCRIPTION
When generating an absolute URL for the Location header in POST responses, default ports (80 for HTTP and 443 for HTTPS) are now stripped. This allows users to always include the port in the X-Forwarded-Host and Forwarded headers without needing to differentiate whether the proxy listens on a default port or not.

In addition, the PR updates the Nginx configuration to include the port number in the forwarded request.

Closes https://github.com/tus/tusd/pull/1190.