### PR TITLE
filestore: Close files correctly when concatenating uploads

### DIFF
--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -240,19 +240,26 @@ func (upload *fileUpload) ConcatUploads(ctx context.Context, uploads []handler.U
 	}()
 
 	for _, partialUpload := range uploads {
-		fileUpload := partialUpload.(*fileUpload)
-
-		src, err := os.Open(fileUpload.binPath)
-		if err != nil {
-			return err
-		}
-
-		if _, err := io.Copy(file, src); err != nil {
+		if err := partialUpload.(*fileUpload).appendTo(ctx, file); err != nil {
 			return err
 		}
 	}
 
 	return
+}
+
+func (upload *fileUpload) appendTo(ctx context.Context, file *os.File) error {
+	src, err := os.Open(upload.binPath)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	if _, err := io.Copy(file, src); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (upload *fileUpload) DeclareLength(ctx context.Context, length int64) error {

--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -253,13 +253,13 @@ func (upload *fileUpload) appendTo(file *os.File) error {
 	if err != nil {
 		return err
 	}
-	defer src.Close()
 
 	if _, err := io.Copy(file, src); err != nil {
+		src.Close()
 		return err
 	}
 
-	return nil
+	return src.Close()
 }
 
 func (upload *fileUpload) DeclareLength(ctx context.Context, length int64) error {

--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -240,7 +240,7 @@ func (upload *fileUpload) ConcatUploads(ctx context.Context, uploads []handler.U
 	}()
 
 	for _, partialUpload := range uploads {
-		if err := partialUpload.(*fileUpload).appendTo(ctx, file); err != nil {
+		if err := partialUpload.(*fileUpload).appendTo(file); err != nil {
 			return err
 		}
 	}
@@ -248,7 +248,7 @@ func (upload *fileUpload) ConcatUploads(ctx context.Context, uploads []handler.U
 	return
 }
 
-func (upload *fileUpload) appendTo(ctx context.Context, file *os.File) error {
+func (upload *fileUpload) appendTo(file *os.File) error {
 	src, err := os.Open(upload.binPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
Provided one solution to [issue #1238](https://github.com/tus/tusd/issues/1238)