### PR TITLE
ci: Install missing Heroku CLI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,6 +102,10 @@ jobs:
       -
         name: Checkout code
         uses: actions/checkout@v4
+        
+      -
+        name: Install Heroku CLI
+        run: curl https://cli-assets.heroku.com/install.sh | sh 
 
       -
         name: Deploy to heroku


### PR DESCRIPTION
Latest Ubuntu images don't include the Heroku CLI anymore, causing deployments to fail.

See https://github.com/AkhileshNS/heroku-deploy/issues/188