### PR TITLE
e2e: Fix flaky network reset test on Windows

### DIFF
--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -433,6 +433,8 @@ Upload-Offset: 0
 		t.Fatal(err)
 	}
 
+	<-time.After(100 * time.Millisecond)
+
 	// Send HEAD request to fetch offset
 	req, err = http.NewRequest("HEAD", uploadUrlStr, nil)
 	if err != nil {


### PR DESCRIPTION
This pull request includes a small change to the `internal/e2e/e2e_test.go` file. The change introduces a delay of 100 milliseconds for the case where the e2e test occasionally failed on the Windows platform.

* [`internal/e2e/e2e_test.go`](diffhunk://#diff-cea4c303dfb5065e669ecfe2ae7edcc051a8c7df40a3c32c990f48deb963095aR436-R437): Added a 100-millisecond delay after encountering a fatal error to ensure proper timing in the test execution.

**Hint**

An alternative solution could be to use `tcpConn.CloseWrite()` between the `conn.Write()` and the `tcpConn.Close()`.

I did a tcpdump and it also sends a RST, but maybe it changes the purpose of this e2e too much.