### PR TITLE
azurestore: Fix the GetOffset to work with enabled Azure blob versioning

### DIFF
--- a/pkg/azurestore/azureservice.go
+++ b/pkg/azurestore/azureservice.go
@@ -193,16 +193,11 @@ func (blockBlob *BlockBlob) GetOffset(ctx context.Context) (int64, error) {
 	var indexes []int
 	var offset int64
 
-	resp, err := blockBlob.BlobClient.GetBlockList(ctx, blockblob.BlockListTypeAll, nil)
+	resp, err := blockBlob.BlobClient.GetBlockList(ctx, blockblob.BlockListTypeUncommitted, nil)
 	if err != nil {
 		return 0, checkForNotFoundError(err)
 	}
 
-	// Need committed blocks to be added to offset to know how big the file really is
-	for _, block := range resp.CommittedBlocks {
-		offset += *block.Size
-		indexes = append(indexes, blockIDBase64ToInt(block.Name))
-	}
 	// Need to get the uncommitted blocks so that we can commit them
 	for _, block := range resp.UncommittedBlocks {
 		offset += *block.Size


### PR DESCRIPTION
azurestore: Fix the GetOffset to work with enabled Azure blob versioning