### PR TITLE
hooks: Add timeout and size limit to HTTP hooks and enforce Content-Type

### DIFF
--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -171,7 +171,7 @@ func ParseFlags() {
 		f.StringVar(&Flags.HttpHooksForwardHeaders, "hooks-http-forward-headers", "", "List of HTTP request headers to be forwarded from the client request to the hook endpoint")
 		f.IntVar(&Flags.HttpHooksRetry, "hooks-http-retry", 3, "Number of times to retry on a 500 or network timeout")
 		f.DurationVar(&Flags.HttpHooksBackoff, "hooks-http-backoff", 1*time.Second, "Wait period before retrying each retry")
-		f.DurationVar(&Flags.HttpHooksTimeout, "hooks-http-timeout", 15*time.Second, "Timeout for the HTTP hook request context")
+		f.DurationVar(&Flags.HttpHooksTimeout, "hooks-http-timeout", 15*time.Second, "Timeout for the HTTP hook requests")
 		f.Int64Var(&Flags.HttpHooksSizeLimit, "hooks-http-size-limit", 5*1024, "Maximum size of the response body in bytes")
 	})
 

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -54,6 +54,8 @@ var Flags struct {
 	HttpHooksForwardHeaders          string
 	HttpHooksRetry                   int
 	HttpHooksBackoff                 time.Duration
+	HttpHooksTimeout                 time.Duration
+	HttpHooksSizeLimit               int64
 	GrpcHooksEndpoint                string
 	GrpcHooksRetry                   int
 	GrpcHooksBackoff                 time.Duration
@@ -169,6 +171,8 @@ func ParseFlags() {
 		f.StringVar(&Flags.HttpHooksForwardHeaders, "hooks-http-forward-headers", "", "List of HTTP request headers to be forwarded from the client request to the hook endpoint")
 		f.IntVar(&Flags.HttpHooksRetry, "hooks-http-retry", 3, "Number of times to retry on a 500 or network timeout")
 		f.DurationVar(&Flags.HttpHooksBackoff, "hooks-http-backoff", 1*time.Second, "Wait period before retrying each retry")
+		f.DurationVar(&Flags.HttpHooksTimeout, "hooks-http-timeout", 15*time.Second, "Timeout for the HTTP hook request context")
+		f.Int64Var(&Flags.HttpHooksSizeLimit, "hooks-http-size-limit", 5*1024, "Maximum size of the response body in bytes")
 	})
 
 	fs.AddGroup("gRPC hook options", func(f *flag.FlagSet) {

--- a/cmd/tusd/cli/hooks.go
+++ b/cmd/tusd/cli/hooks.go
@@ -26,6 +26,8 @@ func getHookHandler(config *handler.Config) hooks.HookHandler {
 			MaxRetries:     Flags.HttpHooksRetry,
 			Backoff:        Flags.HttpHooksBackoff,
 			ForwardHeaders: strings.Split(Flags.HttpHooksForwardHeaders, ","),
+			Timeout:        Flags.HttpHooksTimeout,
+			SizeLimit:      Flags.HttpHooksSizeLimit,
 		}
 	} else if Flags.GrpcHooksEndpoint != "" {
 		printStartupLog("Using '%s' as the endpoint for gRPC hooks", Flags.GrpcHooksEndpoint)

--- a/docs/_advanced-topics/hooks.md
+++ b/docs/_advanced-topics/hooks.md
@@ -285,10 +285,6 @@ $ tusd -hooks-http http://localhost:8081/write
 
 Note that the URL must include the `http://` or `https://` prefix!
 
-#### Timeout and Size Limit
-
-By default, tusd employs a default request timeout of 15s for all HTTP(S) hook to prevent hanging hooks and uploads. In addition, the response content is limited to 5 KiB by default. If you need longer execution time or larger content sizes, you can configure these limits using the `-hooks-http-timeout` and `-hooks-http-size-limit` flags. For detailed information on these flags, run `tusd --help`.
-
 #### Requests
 
 For each hook, tusd will send an individual HTTP request to the provided endpoint. The request body is the JSON-encoded hook request containing more details about the corresponding event. Its values are as described [above](#hook-requests-and-responses).
@@ -299,9 +295,9 @@ The request body also includes all details about the request from the client to 
 
 When the endpoint responds with a non-2XX status code, tusd interprets this as an internal failure. For the pre-create and pre-finish hook, it will stop the processing of the request and respond with a `500 Internal Server Error` to the client. For the other hooks, an error will be logged to tusd's logs, but not error response is sent to the client. Network errors and internal server errors from the hook endpoint will cause the request to be retried, as mentioned [below](#retries).
 
-When the endpoint responds with a 2XX status code, tusd reads the response body and parses it as a JSON-encoded hook response. This allows the hook to customize the HTTP response, reject and abort uploads.
+When the endpoint responds with a 2XX status code, tusd reads the response body and parses it as a JSON-encoded hook response. This allows the hook to customize the HTTP response, reject and abort uploads. Note that tusd requires the `Content-Type: application/json` header to be present in all hook responses.
 
-Tusd requires the `Content-Type` header in all hook responses and strictly validates it to be `application/json`. Responses missing this header or with an unexpected `Content-Type` will be rejected with an error.
+By default, tusd employs a default request timeout of 15s for all HTTP(S) hook to prevent hanging hooks and uploads. In addition, the response content is limited to 5 KiB by default. If you need longer execution time or larger content sizes, you can configure these limits using the `-hooks-http-timeout` and `-hooks-http-size-limit` flags. For detailed information on these flags, run `tusd -help`.
 
 A Python-based example is available at [github.com/tus/tusd/examples/hooks/http](https://github.com/tus/tusd/tree/main/examples/hooks/http).
 

--- a/examples/hooks/http/server.py
+++ b/examples/hooks/http/server.py
@@ -71,6 +71,7 @@ class HTTPHookHandler(BaseHTTPRequestHandler):
         # Send the data from the hook response as JSON output
         response_body = json.dumps(hook_response)
         self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
         self.end_headers()
         self.wfile.write(response_body.encode())
 

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -734,7 +734,6 @@ func TestStopUpload(t *testing.T) {
 	// Start a hook server that always instructs tusd to stop the upload.
 	hookServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"StopUpload":true}`))
 	}))
 	defer hookServer.Close()

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -733,6 +733,8 @@ func TestStopUpload(t *testing.T) {
 
 	// Start a hook server that always instructs tusd to stop the upload.
 	hookServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"StopUpload":true}`))
 	}))
 	defer hookServer.Close()


### PR DESCRIPTION
This PR enhances the HTTP Hooks functionality by introducing several improvements as discussed in issue #1273.

It implements the following:

- **`-hooks-http-timeout` flag:** Allows users to configure a timeout duration for HTTP requests to hook endpoints, preventing indefinite hangs.
- **`-hooks-http-size-limit` flag:** Enables setting a maximum size for HTTP hook response bodies, protecting against potential resource exhaustion from large responses. An error is returned if the limit is exceeded.
- **Content-Type validation:** Ensures that HTTP hook responses have a `Content-Type` of `application/json`.

Furthermore, this PR includes documentation for the newly added `-hooks-http-timeout` and `-hooks-http-size-limit` flags in the HTTP hooks section.

These changes aim to improve the reliability, robustness, and user experience of HTTP hook handling.

Closes #1273.
