### PR TITLE
cli,handler: Add option to disable concatenation extension

### DIFF
--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -22,6 +22,7 @@ var Flags struct {
 	ShowGreeting                     bool
 	DisableDownload                  bool
 	DisableTermination               bool
+	DisableConcatenation             bool
 	DisableCors                      bool
 	CorsAllowOrigin                  string
 	CorsAllowCredentials             bool
@@ -111,6 +112,7 @@ func ParseFlags() {
 		f.BoolVar(&Flags.ExperimentalProtocol, "enable-experimental-protocol", false, "Enable support for the new resumable upload protocol draft from the IETF's HTTP working group, next to the current tus v1 protocol. (experimental and may be removed/changed in the future)")
 		f.BoolVar(&Flags.DisableDownload, "disable-download", false, "Disable the download endpoint")
 		f.BoolVar(&Flags.DisableTermination, "disable-termination", false, "Disable the termination endpoint")
+		f.BoolVar(&Flags.DisableConcatenation, "disable-concatenation", false, "Disable support for the concatenation extension")
 		f.Int64Var(&Flags.MaxSize, "max-size", 0, "Maximum size of a single upload in bytes")
 	})
 

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -41,6 +41,7 @@ func Serve() {
 		EnableExperimentalProtocol:       Flags.ExperimentalProtocol,
 		DisableDownload:                  Flags.DisableDownload,
 		DisableTermination:               Flags.DisableTermination,
+		DisableConcatenation:             Flags.DisableConcatenation,
 		StoreComposer:                    Composer,
 		UploadProgressInterval:           Flags.ProgressHooksInterval,
 		AcquireLockTimeout:               Flags.AcquireLockTimeout,

--- a/pkg/handler/concat_test.go
+++ b/pkg/handler/concat_test.go
@@ -393,4 +393,22 @@ func TestConcat(t *testing.T) {
 			}).Run(handler, t)
 		})
 	})
+
+	SubTest(t, "DisableConcatenation", func(t *testing.T, store *MockFullDataStore, composer *StoreComposer) {
+		handler, _ := NewHandler(Config{
+			BasePath:             "files",
+			StoreComposer:        composer,
+			DisableConcatenation: true,
+		})
+
+		(&httpTest{
+			Method: "POST",
+			ReqHeader: map[string]string{
+				"Tus-Resumable": "1.0.0",
+				"Upload-Concat": "final; http://tus.io/files/aaa/123 /files/bbb/123",
+			},
+			Code:    http.StatusBadRequest,
+			ResBody: "ERR_CONCATENATION_UNSUPPORTED: Upload-Concat header is not supported by server\n",
+		}).Run(handler, t)
+	})
 }

--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -33,6 +33,9 @@ type Config struct {
 	// DisableTermination indicates whether the server will refuse termination
 	// requests of the uploaded file, by not mounting the DELETE handler.
 	DisableTermination bool
+	// DisableConcatenation indicates whether the server will refuse POST requests
+	// for creating uploads that use the concatenation extension.
+	DisableConcatenation bool
 	// Cors can be used to customize the handling of Cross-Origin Resource Sharing (CORS).
 	// See the CorsConfig struct for more details.
 	// Defaults to DefaultCorsConfig.

--- a/pkg/handler/options_test.go
+++ b/pkg/handler/options_test.go
@@ -11,6 +11,9 @@ func TestOptions(t *testing.T) {
 	SubTest(t, "Discovery", func(t *testing.T, store *MockFullDataStore, _ *StoreComposer) {
 		composer := NewStoreComposer()
 		composer.UseCore(store)
+		composer.UseConcater(store)
+		composer.UseTerminater(store)
+		composer.UseLengthDeferrer(store)
 
 		handler, _ := NewHandler(Config{
 			StoreComposer: composer,
@@ -20,7 +23,7 @@ func TestOptions(t *testing.T) {
 		(&httpTest{
 			Method: "OPTIONS",
 			ResHeader: map[string]string{
-				"Tus-Extension": "creation,creation-with-upload",
+				"Tus-Extension": "creation,creation-with-upload,termination,concatenation,creation-defer-length",
 				"Tus-Version":   "1.0.0",
 				"Tus-Resumable": "1.0.0",
 				"Tus-Max-Size":  "400",
@@ -60,6 +63,48 @@ func TestOptions(t *testing.T) {
 			},
 			ResHeader: map[string]string{
 				"Upload-Limit": "min-size=0,max-size=400",
+			},
+			Code: http.StatusOK,
+		}).Run(handler, t)
+	})
+
+	SubTest(t, "DisableConcatenation", func(t *testing.T, store *MockFullDataStore, _ *StoreComposer) {
+		composer := NewStoreComposer()
+		composer.UseCore(store)
+		composer.UseConcater(store)
+
+		handler, _ := NewHandler(Config{
+			StoreComposer:        composer,
+			DisableConcatenation: true,
+		})
+
+		(&httpTest{
+			Method: "OPTIONS",
+			ResHeader: map[string]string{
+				"Tus-Extension": "creation,creation-with-upload",
+				"Tus-Version":   "1.0.0",
+				"Tus-Resumable": "1.0.0",
+			},
+			Code: http.StatusOK,
+		}).Run(handler, t)
+	})
+
+	SubTest(t, "DisableTermination", func(t *testing.T, store *MockFullDataStore, _ *StoreComposer) {
+		composer := NewStoreComposer()
+		composer.UseCore(store)
+		composer.UseTerminater(store)
+
+		handler, _ := NewHandler(Config{
+			StoreComposer:      composer,
+			DisableTermination: true,
+		})
+
+		(&httpTest{
+			Method: "OPTIONS",
+			ResHeader: map[string]string{
+				"Tus-Extension": "creation,creation-with-upload",
+				"Tus-Version":   "1.0.0",
+				"Tus-Resumable": "1.0.0",
 			},
 			Code: http.StatusOK,
 		}).Run(handler, t)

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -54,6 +54,7 @@ var (
 	ErrNotImplemented                   = NewError("ERR_NOT_IMPLEMENTED", "feature not implemented", http.StatusNotImplemented)
 	ErrUploadNotFinished                = NewError("ERR_UPLOAD_NOT_FINISHED", "one of the partial uploads is not finished", http.StatusBadRequest)
 	ErrInvalidConcat                    = NewError("ERR_INVALID_CONCAT", "invalid Upload-Concat header", http.StatusBadRequest)
+	ErrConcatenationUnsupported         = NewError("ERR_CONCATENATION_UNSUPPORTED", "Upload-Concat header is not supported by server", http.StatusBadRequest)
 	ErrModifyFinal                      = NewError("ERR_MODIFY_FINAL", "modifying a final upload is not allowed", http.StatusForbidden)
 	ErrUploadLengthAndUploadDeferLength = NewError("ERR_AMBIGUOUS_UPLOAD_LENGTH", "provided both Upload-Length and Upload-Defer-Length", http.StatusBadRequest)
 	ErrInvalidUploadDeferLength         = NewError("ERR_INVALID_UPLOAD_LENGTH_DEFER", "invalid Upload-Defer-Length header", http.StatusBadRequest)
@@ -125,10 +126,10 @@ func NewUnroutedHandler(config Config) (*UnroutedHandler, error) {
 
 	// Only promote extesions using the Tus-Extension header which are implemented
 	extensions := "creation,creation-with-upload"
-	if config.StoreComposer.UsesTerminater {
+	if config.StoreComposer.UsesTerminater && !config.DisableTermination {
 		extensions += ",termination"
 	}
-	if config.StoreComposer.UsesConcater {
+	if config.StoreComposer.UsesConcater && !config.DisableConcatenation {
 		extensions += ",concatenation"
 	}
 	if config.StoreComposer.UsesLengthDeferrer {
@@ -297,6 +298,11 @@ func (handler *UnroutedHandler) PostFile(w http.ResponseWriter, r *http.Request)
 	var concatHeader string
 	if handler.composer.UsesConcater {
 		concatHeader = r.Header.Get("Upload-Concat")
+	}
+
+	if concatHeader != "" && handler.config.DisableConcatenation {
+		handler.sendError(c, ErrConcatenationUnsupported)
+		return
 	}
 
 	// Parse Upload-Concat header


### PR DESCRIPTION
Even if the storage supports the [concatenation extension](https://tus.io/protocols/resumable-upload#concatenation), an operator may want to disable support for it.

Partial uploads usually have to be treated slightly different in hooks than normal or final uploads. Applications shouldn't process partial uploads as they are just parts of the entire file. In addition, while normal uploads may be moved immediately after their completion, partial uploads should persist for some time until the client has a chance to concatenation them. If the operator does not want to support these cases, they can disable support for the concatenation extension altogether. For this purpose, a new `-disable-concatenation` flag is introduced.

This PR also fixes a minor bug where the termination extension was announced in the Tus-Extension header, although the extension was disabled.