### PR TITLE
Add Concater extension to the GCS storage

### DIFF
--- a/pkg/gcsstore/gcsstore.go
+++ b/pkg/gcsstore/gcsstore.go
@@ -54,6 +54,7 @@ func New(bucket string, service GCSAPI) GCSStore {
 func (store GCSStore) UseIn(composer *handler.StoreComposer) {
 	composer.UseCore(store)
 	composer.UseTerminater(store)
+	composer.UseConcater(store)
 }
 
 func (store GCSStore) NewUpload(ctx context.Context, info handler.FileInfo) (handler.Upload, error) {
@@ -85,6 +86,10 @@ func (store GCSStore) GetUpload(ctx context.Context, id string) (handler.Upload,
 }
 
 func (store GCSStore) AsTerminatableUpload(upload handler.Upload) handler.TerminatableUpload {
+	return upload.(*gcsUpload)
+}
+
+func (store GCSStore) AsConcatableUpload(upload handler.Upload) handler.ConcatableUpload {
 	return upload.(*gcsUpload)
 }
 
@@ -335,6 +340,32 @@ func (upload gcsUpload) GetReader(ctx context.Context) (io.ReadCloser, error) {
 	}
 
 	return store.Service.ReadObject(ctx, params)
+}
+
+func (upload gcsUpload) ConcatUploads(ctx context.Context, partialUploads []handler.Upload) error {
+	names := make([]string, len(partialUploads))
+	store := upload.store
+
+	for i, partialUpload := range partialUploads {
+		info, err := partialUpload.GetInfo(ctx)
+		if err != nil {
+			return err
+		}
+		names[i] = store.keyWithPrefix(info.ID)
+	}
+
+	composeParams := GCSComposeParams{
+		Bucket:      store.Bucket,
+		Destination: store.keyWithPrefix(upload.id),
+		Sources:     names,
+	}
+
+	err := store.Service.ComposeObjects(ctx, composeParams)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (store GCSStore) keyWithPrefix(key string) string {


### PR DESCRIPTION
### Add Concatenation Support to Google Cloud Storage Backend

Uses pretty much the same logic that is used to merge chunks for uploads