### PR TITLE
GCS storage: Do not write info on getInfo

### DIFF
--- a/pkg/gcsstore/gcsstore.go
+++ b/pkg/gcsstore/gcsstore.go
@@ -225,10 +225,6 @@ func (upload gcsUpload) GetInfo(ctx context.Context) (handler.FileInfo, error) {
 	}
 
 	info.Offset = offset
-	err = store.writeInfo(ctx, store.keyWithPrefix(id), info)
-	if err != nil {
-		return info, err
-	}
 
 	return info, nil
 }


### PR DESCRIPTION
I didn't find the reason why is it writing back to info file when reading info (S3 storage is not doing it)

Fixes https://github.com/tus/tusd/issues/343