### PR TITLE
build(deps): use std or local helper to simplify deps

### DIFF
--- a/cmd/tusd/cli/composer.go
+++ b/cmd/tusd/cli/composer.go
@@ -3,11 +3,10 @@ package cli
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/exp/slog"
 
 	"github.com/tus/tusd/v2/internal/s3log"
 	"github.com/tus/tusd/v2/pkg/azurestore"
@@ -20,7 +19,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -3,12 +3,12 @@ package cli
 import (
 	"flag"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/tus/tusd/v2/internal/grouped_flags"
 	"github.com/tus/tusd/v2/pkg/hooks"
-	"golang.org/x/exp/slices"
 )
 
 var Flags struct {

--- a/cmd/tusd/cli/log.go
+++ b/cmd/tusd/cli/log.go
@@ -2,9 +2,8 @@ package cli
 
 import (
 	"log"
+	"log/slog"
 	"os"
-
-	"golang.org/x/exp/slog"
 )
 
 var stdout = log.New(os.Stdout, "", log.LstdFlags|log.Lmicroseconds)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
-	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
@@ -26,12 +25,10 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.7.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/rs/zerolog v1.34.0
 	github.com/sethgrid/pester v1.2.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tus/lockfile v1.2.0
 	github.com/vimeo/go-util v1.4.1
-	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
 	golang.org/x/net v0.49.0
 	golang.org/x/sync v0.19.0
 	google.golang.org/api v0.264.0
@@ -86,7 +83,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.11 // indirect
 	github.com/googleapis/gax-go/v2 v2.16.0 // indirect
-	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
@@ -100,7 +96,6 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/rs/xid v1.6.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.38.0 // indirect
@@ -120,6 +115,5 @@ require (
 	google.golang.org/genproto v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260122232226-8e98ce8d340d // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.54.0/go.mod h1:vB2GH9GAYYJTO3mEn8oYwzEdhlayZIdQz6zdzgUIRvA=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 h1:s0WlVbf9qpvkh1c/uDAPElam0WrL7fHRIidgZJ7UqZI=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
-github.com/Shopify/toxiproxy/v2 v2.12.0 h1:d1x++lYZg/zijXPPcv7PH0MvHMzEI5aX/YuUi/Sw+yg=
-github.com/Shopify/toxiproxy/v2 v2.12.0/go.mod h1:R9Z38Pw6k2cGZWXHe7tbxjGW9azmY1KbDQJ1kd+h7Tk=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
 github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=
@@ -108,7 +106,6 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f h1:Y8xYupdHxryycyPlc9Y+bSQAYZnetRJ70VMVKm5CKI0=
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f/go.mod h1:HlzOvOjVBOfTGSRXRyY0OiCS/3J1akRGQQpRO/7zyF4=
-github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -144,7 +141,6 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.2.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
-github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d h1:lBXNCxVENCipq4D1Is42JVOP4eQjlB8TQ6H69Yx5J9Q=
 github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d/go.mod h1:nnjvkQ9ptGaCkuDUx6wNykzzlUixGxvkme+H/lnzb+A=
@@ -174,8 +170,6 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.11 h1:vAe81Msw+8tKUxi2Dq
 github.com/googleapis/enterprise-certificate-proxy v0.3.11/go.mod h1:RFV7MUdlb7AgEq2v7FmMCfeSMCllAzWxFgRdusoGks8=
 github.com/googleapis/gax-go/v2 v2.16.0 h1:iHbQmKLLZrexmb0OSsNGTeSTS0HO4YvFOG8g5E4Zd0Y=
 github.com/googleapis/gax-go/v2 v2.16.0/go.mod h1:o1vfQjjNZn4+dPnRdl/4ZD7S9414Y4xA+a/6Icj6l14=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
@@ -215,7 +209,6 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
@@ -229,7 +222,6 @@ github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzb
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -246,10 +238,6 @@ github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzM
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
-github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
-github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
-github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
 github.com/sethgrid/pester v1.2.0 h1:adC9RS29rRUef3rIKWPOuP1Jm3/MmB6ke+OhE5giENI=
 github.com/sethgrid/pester v1.2.0/go.mod h1:hEUINb4RqvDxtoCaU0BNT/HV4ig5kfgOasrf1xcvr0A=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -308,8 +296,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 h1:yqrTHse8TCMW1M1ZCP+VAR/l0kKxwaAIqN/il7x4voA=
-golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8/go.mod h1:tujkw807nyEEAamNbDrEGzRav+ilXA7PCRAd6xsmwiU=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -357,7 +343,6 @@ golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
 golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -411,8 +396,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/h2non/gock.v1 v1.1.2 h1:jBbHXgGBK/AoPVfJh5x4r/WxIrElvbLel8TCZkkZJoY=
 gopkg.in/h2non/gock.v1 v1.1.2/go.mod h1:n7UGz/ckNChHiK05rDoiC4MYSunEC/lyaUm2WWaDva0=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/e2e/e2e_unix_test.go
+++ b/internal/e2e/e2e_unix_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	toxiproxy "github.com/Shopify/toxiproxy/v2/client"
+	"github.com/stretchr/testify/require"
 )
 
 // TestShutdown asserts that tusd closes all ongoing upload requests and shuts down
@@ -34,11 +34,11 @@ func TestShutdown(t *testing.T) {
 
 	// We limit the upstream connection to tusd to 5KB/s. The downstream connection
 	// from tusd is not limited.
-	proxy.AddToxic("", "bandwidth", "upstream", 1, toxiproxy.Attributes{
+	proxy.AddToxic("", "bandwidth", "upstream", 1, map[string]any{
 		"rate": 5,
 	})
 
-	// Endpoint address point to toxiproxy
+	// Endpoint address points to the network proxy.
 	endpoint := "http://" + proxy.Listen + "/files/"
 
 	// 50KB of random upload data
@@ -93,8 +93,6 @@ func TestShutdown(t *testing.T) {
 
 	// tusd should close the request and exit immediately after the signal.
 	duration := time.Since(start)
-	if !isApprox(duration, 2*time.Second, 0.1) {
-		t.Fatalf("invalid request duration %v", duration)
-	}
+	require.InDelta(t, 2*time.Second, duration, float64(2*time.Second)*0.1, "invalid request duration %v", duration)
 
 }

--- a/internal/e2e/local_proxy_test.go
+++ b/internal/e2e/local_proxy_test.go
@@ -1,0 +1,321 @@
+package e2e_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+type localProxyClient struct{}
+
+func newLocalProxyClient() *localProxyClient {
+	return &localProxyClient{}
+}
+
+func (*localProxyClient) CreateProxy(_ string, listen, upstream string) (*localProxy, error) {
+	if listen == "" {
+		listen = "127.0.0.1:0"
+	}
+
+	ln, err := net.Listen("tcp", listen)
+	if err != nil {
+		return nil, err
+	}
+
+	proxy := &localProxy{
+		Listen:      ln.Addr().String(),
+		upstream:    upstream,
+		listener:    ln,
+		closed:      make(chan struct{}),
+		connections: make(map[net.Conn]struct{}),
+	}
+
+	proxy.wg.Add(1)
+	go proxy.serve()
+
+	return proxy, nil
+}
+
+type localProxy struct {
+	Listen   string
+	upstream string
+	listener net.Listener
+
+	mu     sync.RWMutex
+	config localProxyConfig
+
+	connMu      sync.Mutex
+	connections map[net.Conn]struct{}
+
+	closeOnce sync.Once
+	closed    chan struct{}
+	wg        sync.WaitGroup
+}
+
+type localProxyConfig struct {
+	upstreamRateBytesPerSecond int64
+	upstreamLimitBytes         int64
+}
+
+type localToxic struct{}
+
+var errUpstreamLimitReached = errors.New("upstream limit reached")
+
+func (proxy *localProxy) AddToxic(_ string, toxicType, stream string, _ float32, attributes map[string]any) (*localToxic, error) {
+	if stream != "upstream" {
+		return nil, fmt.Errorf("unsupported stream %q", stream)
+	}
+
+	proxy.mu.Lock()
+	defer proxy.mu.Unlock()
+
+	switch toxicType {
+	case "bandwidth":
+		rateKBPerSecond, err := int64Attribute(attributes, "rate")
+		if err != nil {
+			return nil, err
+		}
+		if rateKBPerSecond <= 0 {
+			return nil, fmt.Errorf("bandwidth toxic requires rate > 0")
+		}
+		proxy.config.upstreamRateBytesPerSecond = rateKBPerSecond * 1024
+
+	case "limit_data":
+		limitBytes, err := int64Attribute(attributes, "bytes")
+		if err != nil {
+			return nil, err
+		}
+		if limitBytes <= 0 {
+			return nil, fmt.Errorf("limit_data toxic requires bytes > 0")
+		}
+		proxy.config.upstreamLimitBytes = limitBytes
+
+	default:
+		return nil, fmt.Errorf("unsupported toxic type %q", toxicType)
+	}
+
+	return &localToxic{}, nil
+}
+
+func (proxy *localProxy) Delete() error {
+	var closeErr error
+
+	proxy.closeOnce.Do(func() {
+		close(proxy.closed)
+		closeErr = proxy.listener.Close()
+
+		proxy.connMu.Lock()
+		for conn := range proxy.connections {
+			_ = conn.Close()
+		}
+		proxy.connMu.Unlock()
+
+		proxy.wg.Wait()
+	})
+
+	if errors.Is(closeErr, net.ErrClosed) {
+		return nil
+	}
+	return closeErr
+}
+
+func (proxy *localProxy) serve() {
+	defer proxy.wg.Done()
+
+	for {
+		clientConn, err := proxy.listener.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+
+			select {
+			case <-proxy.closed:
+				return
+			default:
+			}
+
+			continue
+		}
+
+		proxy.trackConnection(clientConn)
+		proxy.wg.Add(1)
+		go proxy.handleConnection(clientConn)
+	}
+}
+
+func (proxy *localProxy) handleConnection(clientConn net.Conn) {
+	defer proxy.wg.Done()
+	defer proxy.untrackConnection(clientConn)
+
+	upstreamConn, err := net.Dial("tcp", proxy.upstream)
+	if err != nil {
+		_ = clientConn.Close()
+		return
+	}
+
+	proxy.trackConnection(upstreamConn)
+	defer proxy.untrackConnection(upstreamConn)
+
+	config := proxy.currentConfig()
+	errCh := make(chan error, 2)
+
+	go func() {
+		errCh <- proxy.copyUpstream(upstreamConn, clientConn, config)
+	}()
+
+	go func() {
+		_, err := io.Copy(clientConn, upstreamConn)
+		errCh <- err
+	}()
+
+	firstErr := <-errCh
+
+	_ = clientConn.Close()
+	_ = upstreamConn.Close()
+	<-errCh
+
+	if errors.Is(firstErr, errUpstreamLimitReached) {
+		return
+	}
+}
+
+func (proxy *localProxy) copyUpstream(dst net.Conn, src net.Conn, config localProxyConfig) error {
+	const maxBufferSize = 32 * 1024
+	bufferSize := maxBufferSize
+	if config.upstreamRateBytesPerSecond > 0 {
+		// Keep chunks small enough to avoid large bursts (about 50ms worth of data).
+		bufferSize = int(config.upstreamRateBytesPerSecond / 20)
+		if bufferSize < 1 {
+			bufferSize = 1
+		}
+		if bufferSize > maxBufferSize {
+			bufferSize = maxBufferSize
+		}
+	}
+
+	buffer := make([]byte, bufferSize)
+	sent := int64(0)
+	start := time.Now()
+
+	for {
+		readLimit := len(buffer)
+		if config.upstreamLimitBytes > 0 {
+			remaining := config.upstreamLimitBytes - sent
+			if remaining <= 0 {
+				return errUpstreamLimitReached
+			}
+			if int64(readLimit) > remaining {
+				readLimit = int(remaining)
+			}
+		}
+
+		readLen, readErr := src.Read(buffer[:readLimit])
+		if readLen > 0 {
+			if config.upstreamRateBytesPerSecond > 0 {
+				expectedElapsed := time.Duration(sent+int64(readLen)) * time.Second / time.Duration(config.upstreamRateBytesPerSecond)
+				if sleepFor := time.Until(start.Add(expectedElapsed)); sleepFor > 0 {
+					time.Sleep(sleepFor)
+				}
+			}
+
+			if err := writeAll(dst, buffer[:readLen]); err != nil {
+				return err
+			}
+			sent += int64(readLen)
+
+			if config.upstreamLimitBytes > 0 && sent >= config.upstreamLimitBytes {
+				return errUpstreamLimitReached
+			}
+		}
+
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return nil
+			}
+			return readErr
+		}
+	}
+}
+
+func (proxy *localProxy) currentConfig() localProxyConfig {
+	proxy.mu.RLock()
+	defer proxy.mu.RUnlock()
+
+	return proxy.config
+}
+
+func (proxy *localProxy) trackConnection(conn net.Conn) {
+	proxy.connMu.Lock()
+	defer proxy.connMu.Unlock()
+
+	proxy.connections[conn] = struct{}{}
+}
+
+func (proxy *localProxy) untrackConnection(conn net.Conn) {
+	proxy.connMu.Lock()
+	defer proxy.connMu.Unlock()
+
+	delete(proxy.connections, conn)
+	_ = conn.Close()
+}
+
+func int64Attribute(attributes map[string]any, key string) (int64, error) {
+	rawValue, ok := attributes[key]
+	if !ok {
+		return 0, fmt.Errorf("missing %q attribute", key)
+	}
+
+	switch value := rawValue.(type) {
+	case int:
+		return int64(value), nil
+	case int8:
+		return int64(value), nil
+	case int16:
+		return int64(value), nil
+	case int32:
+		return int64(value), nil
+	case int64:
+		return value, nil
+	case uint:
+		return int64(value), nil
+	case uint8:
+		return int64(value), nil
+	case uint16:
+		return int64(value), nil
+	case uint32:
+		return int64(value), nil
+	case uint64:
+		return int64(value), nil
+	case float32:
+		return floatAttributeToInt64(float64(value), key)
+	case float64:
+		return floatAttributeToInt64(value, key)
+	default:
+		return 0, fmt.Errorf("attribute %q has unsupported type %T", key, rawValue)
+	}
+}
+
+func floatAttributeToInt64(value float64, key string) (int64, error) {
+	intValue := int64(value)
+	if float64(intValue) != value {
+		return 0, fmt.Errorf("attribute %q must be an integer", key)
+	}
+
+	return intValue, nil
+}
+
+func writeAll(dst io.Writer, data []byte) error {
+	for len(data) > 0 {
+		written, err := dst.Write(data)
+		if err != nil {
+			return err
+		}
+		data = data[written:]
+	}
+
+	return nil
+}

--- a/internal/s3log/s3log.go
+++ b/internal/s3log/s3log.go
@@ -5,9 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
-
-	"golang.org/x/exp/slog"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/tus/tusd/v2/pkg/s3store"

--- a/internal/s3log/s3log_test.go
+++ b/internal/s3log/s3log_test.go
@@ -3,10 +3,9 @@ package s3log
 import (
 	"bytes"
 	"context"
+	"log/slog"
 	"strings"
 	"testing"
-
-	"golang.org/x/exp/slog"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"

--- a/pkg/azurestore/azurestore_test.go
+++ b/pkg/azurestore/azurestore_test.go
@@ -283,7 +283,7 @@ func TestWriteChunk(t *testing.T) {
 	data, err := json.Marshal(mockTusdInfo)
 	assert.Nil(err)
 
-	var offset int64 = mockSize / 2
+	var offset = mockSize / 2
 
 	gomock.InOrder(
 		service.EXPECT().NewBlob(ctx, mockID+".info").Return(infoBlob, nil).Times(1),
@@ -327,7 +327,7 @@ func TestFinishUpload(t *testing.T) {
 	data, err := json.Marshal(mockTusdInfo)
 	assert.Nil(err)
 
-	var offset int64 = mockSize / 2
+	var offset = mockSize / 2
 
 	gomock.InOrder(
 		service.EXPECT().NewBlob(ctx, mockID+".info").Return(infoBlob, nil).Times(1),

--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -2,11 +2,10 @@ package handler
 
 import (
 	"errors"
+	"log/slog"
 	"net/url"
 	"regexp"
 	"time"
-
-	"golang.org/x/exp/slog"
 )
 
 // Config provides a way to configure the Handler depending on your needs.

--- a/pkg/handler/context.go
+++ b/pkg/handler/context.go
@@ -3,10 +3,9 @@ package handler
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"time"
-
-	"golang.org/x/exp/slog"
 )
 
 // httpContext is wrapper around context.Context that also carries the

--- a/pkg/handler/unrouted_handler.go
+++ b/pkg/handler/unrouted_handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"math"
 	"mime"
 	"net/http"
@@ -13,8 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/slog"
 )
 
 const UploadLengthDeferred = "1"

--- a/pkg/hooks/file/file.go
+++ b/pkg/hooks/file/file.go
@@ -55,7 +55,7 @@ func (h FileHook) InvokeHook(req hooks.HookRequest) (res hooks.HookResponse, err
 
 	// Report error if the exit code was non-zero
 	if err, ok := err.(*exec.ExitError); ok {
-		return res, fmt.Errorf("unexpected return code %d from hook endpoint: %s", err.ProcessState.ExitCode(), string(output))
+		return res, fmt.Errorf("unexpected return code %d from hook endpoint: %s", err.ExitCode(), string(output))
 	}
 
 	if err != nil {

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -19,11 +19,12 @@ package hooks
 
 import (
 	"fmt"
+	"log/slog"
+	"slices"
+
+	"github.com/tus/tusd/v2/pkg/handler"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/tus/tusd/v2/pkg/handler"
-	"golang.org/x/exp/slices"
-	"golang.org/x/exp/slog"
 )
 
 // HookHandler is the main inferface to be implemented by all hook backends.

--- a/pkg/s3store/s3store.go
+++ b/pkg/s3store/s3store.go
@@ -79,6 +79,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -87,7 +88,6 @@ import (
 	"github.com/tus/tusd/v2/internal/semaphore"
 	"github.com/tus/tusd/v2/internal/uid"
 	"github.com/tus/tusd/v2/pkg/handler"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/aws/aws-sdk-go-v2/aws"


### PR DESCRIPTION
* use more testify for denser code which also drops x/exp constraints reference (only for e2e since other changes touch)

* use std for slog/slices instead of x/exp

* use a simple tcp proxy to drop toxiproxy/zerolog which are only used for e2e tests otherwise