### PR TITLE
Don't run duplicate CI workflow for PRs

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -2,6 +2,8 @@ name: continuous-integration
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Before this, each commit on a PR from a branch in this repo would trigger two CI workflows. One from pushing to the branch and one for updating the PR. This isn't needed. Testing the default branch and the PRs is sufficient.