### PR TITLE
azurestore: Fix offset for completed uploads

### DIFF
--- a/pkg/azurestore/azureservice.go
+++ b/pkg/azurestore/azureservice.go
@@ -200,17 +200,25 @@ func (blockBlob *BlockBlob) Download(ctx context.Context) (io.ReadCloser, error)
 }
 
 func (blockBlob *BlockBlob) GetOffset(ctx context.Context) (int64, error) {
-	// Get the offset of the file from azure storage
-	// For the blob, show each block (ID and size) that is a committed part of it.
-	var indexes []int
 	var offset int64
 
-	resp, err := blockBlob.BlobClient.GetBlockList(ctx, blockblob.BlockListTypeUncommitted, nil)
+	resp, err := blockBlob.BlobClient.GetBlockList(ctx, blockblob.BlockListTypeAll, nil)
 	if err != nil {
 		return 0, checkForNotFoundError(err)
 	}
 
-	// Need to get the uncommitted blocks so that we can commit them
+	// If no uncommitted blocks are found, the upload is complete and we just count
+	// the committed blocks. Unfinished uploads always contain an uncommitted block,
+	// which is created when the upload is started (see NewUpload).
+	// This is necessary to distinguish completed and new uploads when versioning is enabled.
+	if len(resp.UncommittedBlocks) == 0 {
+		for _, block := range resp.CommittedBlocks {
+			offset += *block.Size
+		}
+		return offset, nil
+	}
+
+	var indexes []int
 	for _, block := range resp.UncommittedBlocks {
 		offset += *block.Size
 		indexes = append(indexes, blockIDBase64ToInt(block.Name))

--- a/pkg/azurestore/azurestore.go
+++ b/pkg/azurestore/azurestore.go
@@ -89,6 +89,13 @@ func (store AzureStore) NewUpload(ctx context.Context, info handler.FileInfo) (h
 		return nil, fmt.Errorf("azurestore: unable to create InfoHandler file:\n%s", err)
 	}
 
+	// Stage an empty sentinel block so that "no uncommitted blocks" reliably means upload complete.
+	// Without it we cannot distinguish completed uploads from a new upload that has not written any blocks yet.
+	// Committed blocks exist if versioning is enabled and a blob is overwritten.
+	if err := azUpload.BlockBlob.Upload(ctx, bytes.NewReader([]byte{})); err != nil {
+		return nil, err
+	}
+
 	return azUpload, nil
 }
 

--- a/pkg/azurestore/azurestore_test.go
+++ b/pkg/azurestore/azurestore_test.go
@@ -50,6 +50,7 @@ func TestNewUpload(t *testing.T) {
 	store := azurestore.New(service)
 	store.Container = mockContainer
 
+	blockBlob := NewMockAzBlob(mockCtrl)
 	infoBlob := NewMockAzBlob(mockCtrl)
 	assert.NotNil(infoBlob)
 
@@ -59,9 +60,10 @@ func TestNewUpload(t *testing.T) {
 	r := bytes.NewReader(data)
 
 	gomock.InOrder(
-		service.EXPECT().NewBlob(ctx, mockID).Return(NewMockAzBlob(mockCtrl), nil).Times(1),
+		service.EXPECT().NewBlob(ctx, mockID).Return(blockBlob, nil).Times(1),
 		service.EXPECT().NewBlob(ctx, mockID+".info").Return(infoBlob, nil).Times(1),
 		infoBlob.EXPECT().Upload(ctx, r).Return(nil).Times(1),
+		blockBlob.EXPECT().Upload(ctx, gomock.Any()).Return(nil).Times(1),
 	)
 
 	upload, err := store.NewUpload(context.Background(), mockTusdInfo)
@@ -82,6 +84,7 @@ func TestNewUploadWithPrefix(t *testing.T) {
 	store.Container = mockContainer
 	store.ObjectPrefix = objectPrefix
 
+	blockBlob := NewMockAzBlob(mockCtrl)
 	infoBlob := NewMockAzBlob(mockCtrl)
 	assert.NotNil(infoBlob)
 
@@ -98,9 +101,10 @@ func TestNewUploadWithPrefix(t *testing.T) {
 	r := bytes.NewReader(data)
 
 	gomock.InOrder(
-		service.EXPECT().NewBlob(ctx, objectPrefix+mockID).Return(NewMockAzBlob(mockCtrl), nil).Times(1),
+		service.EXPECT().NewBlob(ctx, objectPrefix+mockID).Return(blockBlob, nil).Times(1),
 		service.EXPECT().NewBlob(ctx, objectPrefix+mockID+".info").Return(infoBlob, nil).Times(1),
 		infoBlob.EXPECT().Upload(ctx, r).Return(nil).Times(1),
+		blockBlob.EXPECT().Upload(ctx, gomock.Any()).Return(nil).Times(1),
 	)
 
 	upload, err := store.NewUpload(context.Background(), mockTusdInfo)


### PR DESCRIPTION
Fixes https://github.com/tus/tusd/issues/1286. As described there, the azurestore has a bug where the offset for a completed upload is reported as 0, instead of the file's actual size.

This PR fixes this by ensuring that unfinished uploads always have at least one uncommitted blocks, which can be used to distinguish completed and new uploads, as suggested by @quality-leftovers in https://github.com/tus/tusd/pull/1287#discussion_r2204409226. Thanks!