### PR TITLE
hooks: Add option to disable TLS verification

### DIFF
--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -61,6 +61,7 @@ var Flags struct {
 	HttpHooksBackoff                 time.Duration
 	HttpHooksTimeout                 time.Duration
 	HttpHooksSizeLimit               int64
+	HttpHooksInsecure                bool
 	GrpcHooksEndpoint                string
 	GrpcHooksRetry                   int
 	GrpcHooksBackoff                 time.Duration
@@ -207,6 +208,7 @@ func ParseFlags() {
 		f.DurationVar(&Flags.HttpHooksBackoff, "hooks-http-backoff", 1*time.Second, "Wait period before retrying each retry")
 		f.DurationVar(&Flags.HttpHooksTimeout, "hooks-http-timeout", 15*time.Second, "Timeout for the HTTP hook requests")
 		f.Int64Var(&Flags.HttpHooksSizeLimit, "hooks-http-size-limit", 5*1024, "Maximum size of the response body in bytes")
+		f.BoolVar(&Flags.HttpHooksInsecure, "hooks-http-insecure", false, "Disables TLS verification for the HTTP hook requests")
 	})
 
 	fs.AddGroup("gRPC hook options", func(f *flag.FlagSet) {

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -61,7 +61,7 @@ var Flags struct {
 	HttpHooksBackoff                 time.Duration
 	HttpHooksTimeout                 time.Duration
 	HttpHooksSizeLimit               int64
-	HttpHooksInsecure                bool
+	HttpHooksInsecureSkipVerify      bool
 	GrpcHooksEndpoint                string
 	GrpcHooksRetry                   int
 	GrpcHooksBackoff                 time.Duration
@@ -208,7 +208,7 @@ func ParseFlags() {
 		f.DurationVar(&Flags.HttpHooksBackoff, "hooks-http-backoff", 1*time.Second, "Wait period before retrying each retry")
 		f.DurationVar(&Flags.HttpHooksTimeout, "hooks-http-timeout", 15*time.Second, "Timeout for the HTTP hook requests")
 		f.Int64Var(&Flags.HttpHooksSizeLimit, "hooks-http-size-limit", 5*1024, "Maximum size of the response body in bytes")
-		f.BoolVar(&Flags.HttpHooksInsecure, "hooks-http-insecure", false, "Disables TLS verification for the HTTP hook requests")
+		f.BoolVar(&Flags.HttpHooksInsecureSkipVerify, "hooks-http-skip-verify", false, "Skip TLS certificate verification for HTTPS hook requests (tls.Config.InsecureSkipVerify)")
 	})
 
 	fs.AddGroup("gRPC hook options", func(f *flag.FlagSet) {

--- a/cmd/tusd/cli/hooks.go
+++ b/cmd/tusd/cli/hooks.go
@@ -28,6 +28,7 @@ func getHookHandler(config *handler.Config) hooks.HookHandler {
 			ForwardHeaders: strings.Split(Flags.HttpHooksForwardHeaders, ","),
 			Timeout:        Flags.HttpHooksTimeout,
 			SizeLimit:      Flags.HttpHooksSizeLimit,
+			Insecure:       Flags.HttpHooksInsecure,
 		}
 	} else if Flags.GrpcHooksEndpoint != "" {
 		printStartupLog("Using '%s' as the endpoint for gRPC hooks", Flags.GrpcHooksEndpoint)

--- a/cmd/tusd/cli/hooks.go
+++ b/cmd/tusd/cli/hooks.go
@@ -22,13 +22,13 @@ func getHookHandler(config *handler.Config) hooks.HookHandler {
 		printStartupLog("Using '%s' as the endpoint for hooks", Flags.HttpHooksEndpoint)
 
 		return &http.HttpHook{
-			Endpoint:       Flags.HttpHooksEndpoint,
-			MaxRetries:     Flags.HttpHooksRetry,
-			Backoff:        Flags.HttpHooksBackoff,
-			ForwardHeaders: strings.Split(Flags.HttpHooksForwardHeaders, ","),
-			Timeout:        Flags.HttpHooksTimeout,
-			SizeLimit:      Flags.HttpHooksSizeLimit,
-			Insecure:       Flags.HttpHooksInsecure,
+			Endpoint:           Flags.HttpHooksEndpoint,
+			MaxRetries:         Flags.HttpHooksRetry,
+			Backoff:            Flags.HttpHooksBackoff,
+			ForwardHeaders:     strings.Split(Flags.HttpHooksForwardHeaders, ","),
+			Timeout:            Flags.HttpHooksTimeout,
+			SizeLimit:          Flags.HttpHooksSizeLimit,
+			InsecureSkipVerify: Flags.HttpHooksInsecureSkipVerify,
 		}
 	} else if Flags.GrpcHooksEndpoint != "" {
 		printStartupLog("Using '%s' as the endpoint for gRPC hooks", Flags.GrpcHooksEndpoint)

--- a/docs/_getting-started/configuration.md
+++ b/docs/_getting-started/configuration.md
@@ -150,7 +150,7 @@ The following example generates a self-signed certificate for `localhost` and th
 
 ```bash
 # Generate self-signed certificate
-$ openssl req -x509 -new -newkey rsa:4096 -nodes -sha256 -days 3650 -keyout localhost.key -out localhost.pem -subj "/CN=localhost"
+$ openssl req -x509 -new -newkey rsa:4096 -nodes -sha256 -days 3650 -keyout localhost.key -out localhost.pem -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
 Generating a 4096 bit RSA private key
 ........................++
 ..........................................++

--- a/pkg/hooks/http/http.go
+++ b/pkg/hooks/http/http.go
@@ -40,9 +40,8 @@ func (h *HttpHook) Setup() error {
 	client.Backoff = func(_ int) time.Duration {
 		return h.Backoff
 	}
-	// The transport uses the same values as the http.DefaultTransport
-	// except for TLSClientConfig.
-	client.Transport = &http.Transport{
+	// The transport uses the same values as the http.DefaultTransport.
+	t := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
@@ -53,11 +52,13 @@ func (h *HttpHook) Setup() error {
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: h.Insecure,
-		},
 	}
+	if h.Insecure {
+		t.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+	client.Transport = t
 
 	h.client = client
 

--- a/pkg/hooks/http/http.go
+++ b/pkg/hooks/http/http.go
@@ -7,6 +7,7 @@ package http
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,6 +26,7 @@ type HttpHook struct {
 	ForwardHeaders []string
 	Timeout        time.Duration
 	SizeLimit      int64
+	Insecure       bool
 
 	client *pester.Client
 }
@@ -36,6 +38,12 @@ func (h *HttpHook) Setup() error {
 	client.MaxRetries = h.MaxRetries
 	client.Backoff = func(_ int) time.Duration {
 		return h.Backoff
+	}
+	client.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: h.Insecure,
+		},
+		ForceAttemptHTTP2: true,
 	}
 
 	h.client = client

--- a/pkg/hooks/http/http.go
+++ b/pkg/hooks/http/http.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"net"
 	"net/http"
 	"time"
 
@@ -39,11 +40,23 @@ func (h *HttpHook) Setup() error {
 	client.Backoff = func(_ int) time.Duration {
 		return h.Backoff
 	}
+	// The transport uses the same values as the http.DefaultTransport
+	// except for TLSClientConfig.
 	client.Transport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: h.Insecure,
 		},
-		ForceAttemptHTTP2: true,
 	}
 
 	h.client = client

--- a/pkg/hooks/http/http.go
+++ b/pkg/hooks/http/http.go
@@ -21,13 +21,13 @@ import (
 )
 
 type HttpHook struct {
-	Endpoint       string
-	MaxRetries     int
-	Backoff        time.Duration
-	ForwardHeaders []string
-	Timeout        time.Duration
-	SizeLimit      int64
-	Insecure       bool
+	Endpoint           string
+	MaxRetries         int
+	Backoff            time.Duration
+	ForwardHeaders     []string
+	Timeout            time.Duration
+	SizeLimit          int64
+	InsecureSkipVerify bool
 
 	client *pester.Client
 }
@@ -53,7 +53,7 @@ func (h *HttpHook) Setup() error {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
-	if h.Insecure {
+	if h.InsecureSkipVerify {
 		t.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true,
 		}


### PR DESCRIPTION
This PR introduces `hooks-http-insecure` flag to the CLI and `Insecure` field to `HttpHook` struct.

If you are wondering, why `ForceAttemptHTTP2: true,` was added to `http.Transport`:

	// InsecureSkipVerify controls whether a client verifies the server's
	// certificate chain and host name. If InsecureSkipVerify is true, crypto/tls
	// accepts any certificate presented by the server and any host name in that
	// certificate. In this mode, TLS is susceptible to machine-in-the-middle
	// attacks unless custom verification is used. This should be used only for
	// testing or in combination with VerifyConnection or VerifyPeerCertificate.
	InsecureSkipVerify bool

	// ForceAttemptHTTP2 controls whether HTTP/2 is enabled when a non-zero
	// Dial, DialTLS, or DialContext func or TLSClientConfig is provided.
	// By default, use of any those fields conservatively disables HTTP/2.
	// To use a custom dialer or TLS config and still attempt HTTP/2
	// upgrades, set this to true.
	ForceAttemptHTTP2 bool

Resolves #1335