### PR TITLE
fix(filelocker): remove stale .stop file when Lock times out

### DIFF
--- a/pkg/filelocker/filelocker.go
+++ b/pkg/filelocker/filelocker.go
@@ -124,11 +124,13 @@ func (lock fileUploadLock) Lock(ctx context.Context, requestRelease func()) erro
 
 		// If we are here, the lock is already held by another entity.
 		// We create the .stop file to signal the lock holder to release the lock.
+		// The handle is closed right away: the holder only checks the file's
+		// existence, and an open handle would block removal on Windows.
 		file, err := os.Create(lock.requestReleaseFile)
 		if err != nil {
 			return err
 		}
-		defer file.Close()
+		file.Close()
 
 		select {
 		case <-ctx.Done():

--- a/pkg/filelocker/filelocker.go
+++ b/pkg/filelocker/filelocker.go
@@ -132,7 +132,11 @@ func (lock fileUploadLock) Lock(ctx context.Context, requestRelease func()) erro
 
 		select {
 		case <-ctx.Done():
-			// Context expired, so we return a timeout
+			// Context expired, so we return a timeout. Since the lock was never
+			// successfully acquired, Unlock() will not be called and the .stop
+			// file would otherwise remain on disk indefinitely. Remove it here
+			// so future acquisition attempts are not affected by stale state.
+			_ = os.Remove(lock.requestReleaseFile)
 			return handler.ErrLockTimeout
 		case <-time.After(lock.acquirerPollInterval):
 			// Continue with the next attempt after a short delay

--- a/pkg/filelocker/filelocker_test.go
+++ b/pkg/filelocker/filelocker_test.go
@@ -60,6 +60,44 @@ func TestFileLocker_Timeout(t *testing.T) {
 	assertEmptyDirectory(dir, a)
 }
 
+func TestFileLocker_Timeout_StopFileCleanedUp(t *testing.T) {
+	// Regression test: when Lock() times out without ever successfully
+	// acquiring the lock, the .stop file it created to signal the holder
+	// must be cleaned up. Otherwise the .stop file remains on disk
+	// indefinitely, which is especially problematic on filesystems where
+	// flock() can return ErrBusy spuriously (e.g. SMB/CIFS) — subsequent
+	// retries observe stale state and fail deterministically.
+	a := assert.New(t)
+
+	dir, err := os.MkdirTemp("", "tusd-file-locker")
+	a.NoError(err)
+
+	locker := New(dir)
+	locker.AcquirerPollInterval = 10 * time.Millisecond
+
+	lock1, err := locker.NewLock("one")
+	a.NoError(err)
+	a.NoError(lock1.Lock(context.Background(), func() {}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	lock2, err := locker.NewLock("one")
+	a.NoError(err)
+	err = lock2.Lock(ctx, func() {
+		panic("must not be called")
+	})
+	a.Equal(err, handler.ErrLockTimeout)
+
+	// The .stop file created by lock2's contended acquisition must not
+	// linger on disk after the acquisition failed.
+	_, err = os.Stat(dir + "/one.stop")
+	a.True(os.IsNotExist(err), "stop file should have been removed after ErrLockTimeout, got err=%v", err)
+
+	a.NoError(lock1.Unlock())
+	assertEmptyDirectory(dir, a)
+}
+
 func TestFileLocker_RequestUnlock(t *testing.T) {
 	a := assert.New(t)
 


### PR DESCRIPTION
Fixes #1372.

When `Lock()` creates a `.stop` file to signal release to the current holder and then times out without acquiring the lock, the `.stop` file was previously only removed by a successful `Unlock()` — which is never called for a failed acquisition. The leftover file persisted on disk until the next successful `Unlock()` of the same upload ID.

On filesystems where `flock()` can return `ErrBusy` spuriously (notably SMB/CIFS), failed acquisitions left permanent stale state that broke all subsequent retries with `ERR_LOCK_TIMEOUT` even when no other process held the lock.

This patch cleans up the `.stop` file directly in the `ctx.Done()` branch of `Lock()` and adds a regression test that asserts `one.stop` is gone after a contended `Lock()` times out without the held lock being released.